### PR TITLE
Reset 4 of the 5 legacy apps to the "live" website url in detection m…

### DIFF
--- a/environments/prod/prod.tfvars
+++ b/environments/prod/prod.tfvars
@@ -13,49 +13,53 @@ cdn_sku            = "Standard_Verizon"
 frontends = [
   {
     name           = "dts-legacy-apps---certificatedbailiffs"
-    mode           = "Detection" #detection config set and PR raised 20 Dec 2021
-    custom_domain  = "waf.certificatedbailiffs.justice.gov.uk"
+    mode           = "Detection"
+    custom_domain  = "certificatedbailiffs.justice.gov.uk"
     backend_domain = ["dualstack.certi-loadb-q2s48nuaqsc6-1478330638.eu-west-2.elb.amazonaws.com"]
     shutter_app    = false
   },
   {
     name           = "dts-legacy-apps---civilappeals-casetracker"
-    mode           = "Detection" #detection config set and PR raised 20 Dec 2021
-    custom_domain  = "waf.casetracker.justice.gov.uk"
+    mode           = "Detection"
+    custom_domain  = "casetracker.justice.gov.uk"
     backend_domain = ["dualstack.civil-loadb-qvbu457dp1b-1835055660.eu-west-2.elb.amazonaws.com"]
     shutter_app    = false
   },
   {
     name           = "dts-legacy-apps---courtfines"
-    mode           = "Detection" #detection config set and PR raised 20 Dec 2021
-    custom_domain  = "waf.courtfines.direct.gov.uk"
+    mode           = "Detection"
+    custom_domain  = "courtfines.direct.gov.uk"
     backend_domain = ["dualstack.court-loadb-8mcola2l2by0-173012739.eu-west-2.elb.amazonaws.com"]
     shutter_app    = false
   },
   {
     name           = "dts-legacy-apps---immigration-appeals-iacfees"
-    mode           = "Detection" #detection config set and PR raised 20 Dec 2021
-    custom_domain  = "waf.immigrationappealsonline.justice.gov.uk"
+    mode           = "Detection"
+    custom_domain  = "immigrationappealsonline.justice.gov.uk"
     backend_domain = ["dualstack.iacfees-p-elbhmcts-6jxi2y1j3cgc-1579084157.eu-west-1.elb.amazonaws.com"]
     shutter_app    = false
   },
   {
+    name           = "dts-legacy-apps---utiac"
+    mode           = "Detection"
+    custom_domain  = "waf.tribunalsdecisions.service.gov.uk"
+    backend_domain = ["dualstack.dtsla-utiac-lb-prod-1989357889.eu-west-1.elb.amazonaws.com"]
+    shutter_app    = false
+  },
+  {
     name           = "dts-legacy-apps---redirect-service"
-    mode           = "Detection" #detection config set and PR raised 20 Dec 2021
-    custom_domain  = "proxywaf.digital.justice.gov.uk"
+    mode           = "Detection"
+    custom_domain  = "proxy.digital.justice.gov.uk"
     backend_domain = ["52.30.196.9"]
     shutter_app    = false
   },
   {
-    name           = "dts-legacy-apps---utiac"
-    mode           = "Detection" #detection config set and PR raised 20 Dec 2021
-    custom_domain  = "waf.tribunalsdecisions.service.gov.uk"
-    backend_domain = ["dualstack.dsd-apps-lb-01-1379550980.eu-west-1.elb.amazonaws.com"]
+    name           = "dts-legacy-apps---redirect-service-waf"
+    mode           = "Detection"
+    custom_domain  = "proxywaf.digital.justice.gov.uk"
+    backend_domain = ["52.30.196.9"]
     shutter_app    = false
   },
-
-  
-
   {
     name           = "trib-land-reg-division"
     mode           = "Prevention"


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RST-4090

### Change description ###

Reset 4 of the 5 legacy apps to the "live" website url in Front-Door detection mode.
This will be in place for 2 weeks to gather/analyse traffic before setting in prevention mode
Leave tribunalsdecisions as a "waf" domain because the backend lb domain url was previously incorrect. We need to verify the redirection using the waf subdomain first


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
