### PR TITLE
add default next hop IP to Palo for APIM

### DIFF
--- a/components/apim/local.tf
+++ b/components/apim/local.tf
@@ -1,0 +1,30 @@
+locals {
+
+  hub = {
+    nonprod = {
+      ukSouth = {
+        next_hop_ip = "10.11.72.36"
+      }
+      ukWest = {
+        next_hop_ip = "10.49.72.36"
+      }
+    }
+    sbox = {
+      ukSouth = {
+        next_hop_ip = "10.10.200.36"
+      }
+      ukWest = {
+        next_hop_ip = "10.48.200.36"
+      }
+    }
+    prod = {
+      ukSouth = {
+        next_hop_ip = "10.11.8.36"
+      }
+      ukWest = {
+        next_hop_ip = "10.49.8.36"
+      }
+    }
+  }
+
+}

--- a/components/apim/main.tf
+++ b/components/apim/main.tf
@@ -15,6 +15,7 @@ module "api-mgmt" {
   virtual_network_type           = "Internal"
   department                     = var.department
   common_tags                    = module.ctags.common_tags
+  route_next_hop_in_ip_address   = local.hub[var.hub].ukSouth.next_hop_ip
 }
 
 resource "azurerm_api_management_named_value" "environment" {

--- a/environments/variable.tf
+++ b/environments/variable.tf
@@ -20,3 +20,4 @@ variable "shutter_rg" { default = "" }
 variable "cdn_sku" { default = "" }
 variable "department" { default = "sds" }
 variable "apim_sku_name" { default = "Developer" }
+variable "hub" { default = "sbox" }


### PR DESCRIPTION
### Change description ###
add default next hop IP to Palo for APIM
- Did not add the other .tfvars in terms of the "hub" as not sure which environments we will deploy APIM onto yet

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
