### PR TITLE
Change the name of the staging-casetracker front door resource to mat…

### DIFF
--- a/environments/stg/stg.tfvars
+++ b/environments/stg/stg.tfvars
@@ -53,7 +53,7 @@ frontends = [
     disabled_rules = {}
   },
   {
-    name           = "dts-legacy-apps-civilappeals-casetracker"
+    name           = "staging-casetracker"
     mode           = "Detection"
     custom_domain  = "staging-casetracker.justice.gov.uk"
     backend_domain = ["civil-loadb-105un4gbv5077-2040046462.eu-west-2.elb.amazonaws.com"]


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RST-4090

### Change description ###

Change the name of the staging-casetracker front door resource to match the domain name and to force a new record creation.
The current resource is stuck in domain validation

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
