### PR TITLE
Bumping apim terraform to 2.97.0

### DIFF
--- a/components/apim/init.tf
+++ b/components/apim/init.tf
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "2.82.0"
+      version = "2.97.0"
     }
   }
 }


### PR DESCRIPTION
### Change description ###
Bumping apim terraform to 2.97.0
- Will manually delete sbox apim before merging as its deployed using terraform arm template

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
