### PR TITLE
PUB-1117 - exclude open id body parameters

### DIFF
--- a/environments/prod/prod.tfvars
+++ b/environments/prod/prod.tfvars
@@ -461,6 +461,19 @@ frontends = [
     certificate_name = "wildcard-platform-hmcts-net"
     shutter_app      = true
     disabled_rules   = {}
+    global_exclusions = [
+      ## Open ID response parameters
+      {
+        match_variable = "RequestBodyPostArgNames"
+        operator       = "Equals"
+        selector       = "code"
+      },
+      {
+        match_variable = "RequestBodyPostArgNames"
+        operator       = "Equals"
+        selector       = "state"
+      }
+    ]
   },
   {
     name             = "vh-test-web"

--- a/environments/stg/stg.tfvars
+++ b/environments/stg/stg.tfvars
@@ -23,6 +23,20 @@ frontends = [
     backend_domain = ["firewall-prod-int-palo-sdsstg.uksouth.cloudapp.azure.com"]
 
     disabled_rules = {}
+    
+    global_exclusions = [
+      ## Open ID response parameters
+      {
+        match_variable = "RequestBodyPostArgNames"
+        operator       = "Equals"
+        selector       = "code"
+      },
+      {
+        match_variable = "RequestBodyPostArgNames"
+        operator       = "Equals"
+        selector       = "state"
+      }
+    ]
   },
   {
     name           = "vh-test-web"

--- a/environments/test/test.tfvars
+++ b/environments/test/test.tfvars
@@ -24,6 +24,20 @@ frontends = [
     backend_domain = ["firewall-prod-int-palo-sdstest.uksouth.cloudapp.azure.com"]
 
     disabled_rules = {}
+    
+    global_exclusions = [
+      ## Open ID response parameters
+      {
+        match_variable = "RequestBodyPostArgNames"
+        operator       = "Equals"
+        selector       = "code"
+      },
+      {
+        match_variable = "RequestBodyPostArgNames"
+        operator       = "Equals"
+        selector       = "state"
+      }
+    ]
   },
   {
     name           = "vh-test-web"


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PUB-1117


### Change description ###
Az Fd is currently blocking the tokens returned by Azure Open ID due to the characters in the body.
This exclusion should allow these parameters to bypass


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x ] No
```
