### PR TITLE
Search of certificatedbailiffs is not working after the first page. T…

### DIFF
--- a/environments/stg/stg.tfvars
+++ b/environments/stg/stg.tfvars
@@ -95,6 +95,7 @@ frontends = [
     backend_domain = ["dualstack.certi-loadb-vzujs6ulbuut-415542592.eu-west-2.elb.amazonaws.com"]
     shutter_app    = false
     enable_ssl     = true
+    session_affinity = true
   },
   {
     name           = "staging-courtfines"


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RST-4380

### Change description ###

Search of certificatedbailiffs is not working after the first page. Test whether enabling session affinity will solve it (in staging first)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
