### PR TITLE
Added cookie exclusion for PIP Frontend

### DIFF
--- a/environments/ithc/ithc.tfvars
+++ b/environments/ithc/ithc.tfvars
@@ -79,6 +79,11 @@ frontends = [
         match_variable = "RequestCookieNames"
         operator       = "Equals"
         selector       = "dtSa"
+      },
+      {
+        match_variable = "RequestCookieNames"
+        operator       = "Equals"
+        selector       = "cookiePolicy"
       }
     ]
   }

--- a/environments/prod/prod.tfvars
+++ b/environments/prod/prod.tfvars
@@ -539,6 +539,11 @@ frontends = [
         match_variable = "RequestCookieNames"
         operator       = "Equals"
         selector       = "dtSa"
+      },
+      {
+        match_variable = "RequestCookieNames"
+        operator       = "Equals"
+        selector       = "cookiePolicy"
       }
     ]
   },

--- a/environments/stg/stg.tfvars
+++ b/environments/stg/stg.tfvars
@@ -51,6 +51,11 @@ frontends = [
         match_variable = "RequestCookieNames"
         operator       = "Equals"
         selector       = "dtSa"
+      },
+      {
+        match_variable = "RequestCookieNames"
+        operator       = "Equals"
+        selector       = "cookiePolicy"
       }
     ]
   },

--- a/environments/test/test.tfvars
+++ b/environments/test/test.tfvars
@@ -51,6 +51,11 @@ frontends = [
         match_variable = "RequestCookieNames"
         operator       = "Equals"
         selector       = "dtSa"
+      },
+      {
+        match_variable = "RequestCookieNames"
+        operator       = "Equals"
+        selector       = "cookiePolicy"
       }
     ]
   },


### PR DESCRIPTION
### JIRA link (if applicable) ###

N/A

### Change description ###

Added exclusion to cookiePolicy for pip-frontend. This cookie is used to store preferences for the user, and is currently being blocked.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
