### PR TITLE
PIP-Frontend - Further Cookie

### DIFF
--- a/environments/ithc/ithc.tfvars
+++ b/environments/ithc/ithc.tfvars
@@ -84,6 +84,11 @@ frontends = [
         match_variable = "RequestCookieNames"
         operator       = "Equals"
         selector       = "cookiePolicy"
+      },
+      {
+        match_variable = "RequestCookieNames"
+        operator       = "Equals"
+        selector       = "createAdminAccount"
       }
     ]
   }

--- a/environments/prod/prod.tfvars
+++ b/environments/prod/prod.tfvars
@@ -544,6 +544,11 @@ frontends = [
         match_variable = "RequestCookieNames"
         operator       = "Equals"
         selector       = "cookiePolicy"
+      },
+      {
+        match_variable = "RequestCookieNames"
+        operator       = "Equals"
+        selector       = "createAdminAccount"
       }
     ]
   },

--- a/environments/stg/stg.tfvars
+++ b/environments/stg/stg.tfvars
@@ -56,6 +56,11 @@ frontends = [
         match_variable = "RequestCookieNames"
         operator       = "Equals"
         selector       = "cookiePolicy"
+      },
+      {
+        match_variable = "RequestCookieNames"
+        operator       = "Equals"
+        selector       = "createAdminAccount"
       }
     ]
   },

--- a/environments/test/test.tfvars
+++ b/environments/test/test.tfvars
@@ -56,6 +56,11 @@ frontends = [
         match_variable = "RequestCookieNames"
         operator       = "Equals"
         selector       = "cookiePolicy"
+      },
+      {
+        match_variable = "RequestCookieNames"
+        operator       = "Equals"
+        selector       = "createAdminAccount"
       }
     ]
   },


### PR DESCRIPTION
### JIRA link (if applicable) ###

N/A

### Change description ###

Added a further cookie to PIP Frontend. This cookie is used in the create-admin-account screens to store state. It's currently being blocked by frontdoor.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
