### PR TITLE
DTSPO-9055 - Remove toffee sbox custom rules

### DIFF
--- a/environments/sbox/sbox.tfvars
+++ b/environments/sbox/sbox.tfvars
@@ -18,7 +18,6 @@ frontends = [
     certificate_name = "wildcard-sandbox-platform-hmcts-net"
     backend_domain   = ["firewall-sbox-int-palo-sdssbox.uksouth.cloudapp.azure.com"]
     disabled_rules   = {}
-    enable_ssl       = true
   },
   {
     product          = "sds-api-mgmt"

--- a/environments/sbox/sbox.tfvars
+++ b/environments/sbox/sbox.tfvars
@@ -18,6 +18,7 @@ frontends = [
     certificate_name = "wildcard-sandbox-platform-hmcts-net"
     backend_domain   = ["firewall-sbox-int-palo-sdssbox.uksouth.cloudapp.azure.com"]
     disabled_rules   = {}
+    enable_ssl       = true
   },
   {
     product          = "sds-api-mgmt"

--- a/environments/sbox/sbox.tfvars
+++ b/environments/sbox/sbox.tfvars
@@ -18,25 +18,6 @@ frontends = [
     certificate_name = "wildcard-sandbox-platform-hmcts-net"
     backend_domain   = ["firewall-sbox-int-palo-sdssbox.uksouth.cloudapp.azure.com"]
     disabled_rules   = {}
-
-    custom_rules = [
-      {
-        name     = "IPMatchWhitelist"
-        priority = 1
-        type     = "MatchRule"
-        action   = "Block"
-        match_conditions = [
-          {
-            match_variable     = "RemoteAddr"
-            operator           = "IPMatch"
-            negation_condition = true
-            match_values = [
-              "51.145.4.100/32"
-            ]
-          }
-        ]
-      },
-    ],
   },
   {
     product          = "sds-api-mgmt"


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DSTP0-9055


### Change description ###
Remove custom rule that restricts toffee sbox to connections on vpn
Terraform plan will attempt to destroy some vh-admin and video web related resources (not related to this pr) but these are failing in the latest applies anyway.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
