### PR TITLE
Included toffee as a frontend, added both clusters as destinations

### DIFF
--- a/environments/demo/backend_lb_config.yaml
+++ b/environments/demo/backend_lb_config.yaml
@@ -10,3 +10,6 @@ gateways:
     app_configuration:
       - product: dummy
         component: app
+      - product: toffee
+        component: recipe-backend
+

--- a/environments/demo/demo.tfvars
+++ b/environments/demo/demo.tfvars
@@ -4,7 +4,7 @@ env                = "demo"
 subscription       = "demo"
 oms_env            = "demo"
 private_ip_address = "10.51.96.133"
-destinations       = ["10.51.95.250"]
+destinations       = ["10.51.79.250", "10.51.95.250"]
 vnet_rg            = "ss-demo-network-rg"
 vnet_name          = "ss-demo-vnet"
 hub                = "nonprod"
@@ -49,5 +49,12 @@ frontends = [
         ]
       }
     ]
+  },
+  {
+    product          = "toffee"
+    name             = "toffee"
+    custom_domain    = "plum-public.demo.platform.hmcts.net"
+    backend_domain   = ["firewall-nonprodi-palo-sdsdemoappgateway.uksouth.cloudapp.azure.com"]
+    certificate_name = "wildcard-demo-platform-hmcts-net"
   }
 ]

--- a/environments/demo/demo.tfvars
+++ b/environments/demo/demo.tfvars
@@ -53,7 +53,7 @@ frontends = [
   {
     product          = "toffee"
     name             = "toffee"
-    custom_domain    = "plum-public.demo.platform.hmcts.net"
+    custom_domain    = "toffee.demo.platform.hmcts.net"
     backend_domain   = ["firewall-nonprodi-palo-sdsdemoappgateway.uksouth.cloudapp.azure.com"]
     certificate_name = "wildcard-demo-platform-hmcts-net"
   }


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DTSPO-12424 

This code:

- Adds both demo clusters as backend targets for backends in this appgw
- Includes toffee in the appgw backend pool
- Depends on PIP creation in https://github.com/hmcts/rdo-terraform-hub-dmz/pull/723/files

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
