### PR TITLE
Azure FrontDoor is suddenly blocking requests on the /Admin urls.

### DIFF
--- a/environments/stg/stg.tfvars
+++ b/environments/stg/stg.tfvars
@@ -344,18 +344,18 @@ frontends = [
     ]
     custom_rules = [
       {
-        name = "AllowAllAdmin",
-        type = "MatchRule"
+        name     = "AllowAllAdmin",
+        type     = "MatchRule"
         priority = 1
-        action = "Allow"
+        action   = "Allow"
 
         match_conditions = [
           {
-            match_variable = "RequestUri"
-            operator = "Contains"
+            match_variable     = "RequestUri"
+            operator           = "Contains"
             negation_condition = false
             match_values = [
-              "/Admin"]
+            "/Admin"]
           }
         ]
       }

--- a/environments/stg/stg.tfvars
+++ b/environments/stg/stg.tfvars
@@ -342,6 +342,24 @@ frontends = [
         selector       = "__EVENTVALIDATION"
       }
     ]
+    custom_rules = [
+      {
+        name = "AllowAllAdmin",
+        type = "MatchRule"
+        priority = 1
+        action = "Allow"
+
+        match_conditions = [
+          {
+            match_variable = "RequestUri"
+            operator = "Contains"
+            negation_condition = false
+            match_values = [
+              "/Admin"]
+          }
+        ]
+      }
+    ]
   },
   {
     name           = "staging-trib-immigration-svcs"


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RST-5234

### Change description ###
Azure FrontDoor is suddenly blocking requests on the /Admin urls.
See if this custom rule allows them
/Admin URL password protected an blocked by an MoJ VPN ip filter

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
