### PR TITLE
Add ssl_enabled flag to allow 443 listeners

### DIFF
--- a/environments/demo/backend_lb_config.yaml
+++ b/environments/demo/backend_lb_config.yaml
@@ -28,14 +28,19 @@ gateways:
       # VH
       - product: vh
         component: bookings-api
+        ssl_enabled: true
       - product: vh
         component: notification-api
+        ssl_enabled: true
       - product: vh
         component: test-api
+        ssl_enabled: true
       - product: vh
         component: user-api
+        ssl_enabled: true
       - product: vh
         component: video-api
+        ssl_enabled: true
 
       # My-Time
       - product: my-time


### PR DESCRIPTION
This change:
- Fixes demo appgw not listening on port 443 for VH backends and causing app to not run


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
