### PR TITLE
Remove certificate_name field for portal-dev

### DIFF
--- a/environments/dev/dev.tfvars
+++ b/environments/dev/dev.tfvars
@@ -324,7 +324,6 @@ frontends = [
     mode                = "Prevention"
     custom_domain       = "portal-dev.pre-recorded-evidence.justice.gov.uk"
     backend_domain      = ["pre-dev.powerappsportals.com"]
-    certificate_name    = "portal-dev-pre-recorded-evidence-justice-gov-uk"
     disabled_rules      = {}
     shutter_app         = false
     health_path         = "/SignIn?ReturnUrl=%2F"


### PR DESCRIPTION
### Change description ###
we aren't using acme certs so shouldn't need this


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
