### PR TITLE
PUB-2085 - Removed old pip frontend domain

### DIFF
--- a/environments/prod/prod.tfvars
+++ b/environments/prod/prod.tfvars
@@ -715,16 +715,6 @@ frontends = [
     disabled_rules = {}
   },
   {
-    name              = "pip-frontend"
-    custom_domain     = "pip-frontend.platform.hmcts.net"
-    backend_domain    = ["firewall-prod-int-palo-sdsprod.uksouth.cloudapp.azure.com"]
-    certificate_name  = "wildcard-platform-hmcts-net"
-    disabled_rules    = {}
-    global_exclusions = []
-    dns_zone_name     = "platform.hmcts.net"
-
-  },
-  {
     name             = "court-tribunal-hearings"
     custom_domain    = "www.court-tribunal-hearings.service.gov.uk"
     backend_domain   = ["firewall-prod-int-palo-sdsprod.uksouth.cloudapp.azure.com"]


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/PUB-2085

### Change description ###

Remove old PIP DNS from frontend, as it is no longer used / does not work