### PR TITLE
fixing dev frontdoor

### DIFF
--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -153,9 +153,9 @@ parameters:
         environment: 'sbox'
         dependsOn: 'Precheck'
         pipeline_tests: false
-      # - deployment: 'frontdoor'
-      #   environment: 'dev'
-      #   dependsOn: 'sbox_frontdoor'
+      - deployment: 'frontdoor'
+        environment: 'dev'
+        dependsOn: 'sbox_frontdoor'
       - deployment: 'frontdoor'
         environment: 'stg'
         dependsOn: 'sbox_frontdoor'

--- a/environments/dev/dev.tfvars
+++ b/environments/dev/dev.tfvars
@@ -408,7 +408,7 @@ frontends = [
     custom_domain  = "dev.landregistrationdivision.dsd.io"
     backend_domain = ["dts-tribs-dev-317402065.eu-west-1.elb.amazonaws.com"]
     shutter_app    = false
-    enable_ssl     = false
+
 
     global_exclusions = [
       {
@@ -429,7 +429,7 @@ frontends = [
     custom_domain  = "dev.immigrationservices.dsd.io"
     backend_domain = ["dts-tribs-dev-317402065.eu-west-1.elb.amazonaws.com"]
     shutter_app    = false
-    enable_ssl     = false
+
 
     global_exclusions = [
       {
@@ -445,7 +445,7 @@ frontends = [
     custom_domain  = "dev.informationrights.dsd.io"
     backend_domain = ["dts-tribs-dev-317402065.eu-west-1.elb.amazonaws.com"]
     shutter_app    = false
-    enable_ssl     = false
+
 
     global_exclusions = [
       {
@@ -476,7 +476,7 @@ frontends = [
     custom_domain  = "dev.administrativeappeals.dsd.io"
     backend_domain = ["dts-tribs-dev-317402065.eu-west-1.elb.amazonaws.com"]
     shutter_app    = false
-    enable_ssl     = false
+
 
     global_exclusions = [
       {
@@ -497,7 +497,7 @@ frontends = [
     custom_domain  = "dev.carestandards.dsd.io"
     backend_domain = ["dts-tribs-dev-317402065.eu-west-1.elb.amazonaws.com"]
     shutter_app    = false
-    enable_ssl     = false
+
 
     global_exclusions = [
       {
@@ -528,7 +528,7 @@ frontends = [
     custom_domain  = "dev.landschamber.dsd.io"
     backend_domain = ["dts-tribs-dev-317402065.eu-west-1.elb.amazonaws.com"]
     shutter_app    = false
-    enable_ssl     = false
+
 
     global_exclusions = [
       {
@@ -544,7 +544,7 @@ frontends = [
     custom_domain  = "dev.financeandtax.dsd.io"
     backend_domain = ["dts-tribs-dev-317402065.eu-west-1.elb.amazonaws.com"]
     shutter_app    = false
-    enable_ssl     = false
+
 
     disabled_rules = {
       SQLI = [
@@ -583,7 +583,7 @@ frontends = [
     custom_domain  = "dev.employmentappeals.dsd.io"
     backend_domain = ["dts-tribs-dev-317402065.eu-west-1.elb.amazonaws.com"]
     shutter_app    = false
-    enable_ssl     = false
+
 
     global_exclusions = [
       {
@@ -599,7 +599,7 @@ frontends = [
     custom_domain  = "dev.transportappeals.dsd.io"
     backend_domain = ["dts-tribs-dev-317402065.eu-west-1.elb.amazonaws.com"]
     shutter_app    = false
-    enable_ssl     = false
+
 
     global_exclusions = [
       {
@@ -655,7 +655,7 @@ frontends = [
     custom_domain  = "dev.cicap.dsd.io"
     backend_domain = ["dts-tribs-dev-317402065.eu-west-1.elb.amazonaws.com"]
     shutter_app    = false
-    enable_ssl     = false
+
 
     global_exclusions = [
       {


### PR DESCRIPTION
### Jira link (if applicable)



### Change description ###
In order to solve this error on the frontdoor

```
The host 'dev.landregistrationdivision.dsd.io' is missing a default route '/*' path for the HTTPS protocol.
The host 'dev.immigrationservices.dsd.io' is missing a default route '/*' path for the HTTPS protocol.
The host 'dev.administrativeappeals.dsd.io' is missing a default route '/*' path for the HTTPS protocol.
The host 'dev.employmentappeals.dsd.io' is missing a default route '/*' path for the HTTPS protocol.
The host 'dev.financeandtax.dsd.io' is missing a default route '/*' path for the HTTPS protocol.
The host 'dev.landschamber.dsd.io' is missing a default route '/*' path for the HTTPS protocol.
The host 'dev.cicap.dsd.io' is missing a default route '/*' path for the HTTPS protocol.
The host 'dev.carestandards.dsd.io' is missing a default route '/*' path for the HTTPS protocol.
The host 'dev.transportappeals.dsd.io' is missing a default route '/*' path for the HTTPS protocol.
The host 'dev.informationrights.dsd.io' is missing a default route '/*' path for the HTTPS protocol.
```
