### PR TITLE
DTSPO-15318: Add sds sbox jenkins static redirect

### DIFF
--- a/environments/prod/prod.tfvars
+++ b/environments/prod/prod.tfvars
@@ -1196,6 +1196,13 @@ frontends = [
     shutter_app   = false
     redirect      = "sds-sandbox-build.hmcts.net"
   },
+  {
+    name          = "static-sds-sandbox-build"
+    custom_domain = "static-sds-sandbox-build.platform.hmcts.net"
+    dns_zone_name = "platform.hmcts.net"
+    shutter_app   = false
+    redirect      = "static-sds-sandbox-build.hmcts.net"
+  },
 ]
 
 


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DTSPO-15318

Adds redirect for sds sbox jenkins static  -- will add the cname records after , when I added before previously there was an error of 

```
Another custom domain with the same host name already exists.
```


<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
