### PR TITLE
post SDS frontdoor migration clean up

### DIFF
--- a/components/frontdoor/main.tf
+++ b/components/frontdoor/main.tf
@@ -24,33 +24,7 @@ locals {
   vault_name              = "acme${replace(local.subscription_short_name, "-", "")}"
 }
 
-module "landing_zone" {
-  count  = var.upgrade_frontdoor ? 0 : 1
-  source = "git::https://github.com/hmcts/terraform-module-frontdoor.git?ref=master"
-
-  common_tags                = module.ctags.common_tags
-  env                        = var.env
-  project                    = var.project
-  location                   = var.location
-  frontends                  = var.frontends
-  ssl_mode                   = "FrontDoor"
-  resource_group             = azurerm_resource_group.fd_rg.name
-  subscription_id            = data.azurerm_subscription.current.subscription_id
-  certificate_key_vault_name = local.vault_name
-  oms_env                    = var.oms_env
-  certificate_name_check     = true
-  key_vault_resource_group   = "sds-platform-${var.environment}-rg"
-  log_analytics_workspace_id = module.logworkspace.workspace_id
-
-  diagnostics_storage_account_id    = azurerm_storage_account.diagnostics.id
-  send_access_logs_to_log_analytics = false
-}
-moved {
-  from = module.landing_zone
-  to   = module.landing_zone[0]
-}
 module "premium_front_door" {
-  count  = var.upgrade_frontdoor ? 1 : 0
   source = "git::https://github.com/hmcts/terraform-module-frontdoor.git?ref=DTSPO-13992-test-new-version-of-frontdoor"
 
   common_tags                = module.ctags.common_tags

--- a/components/frontdoor/main.tf
+++ b/components/frontdoor/main.tf
@@ -24,6 +24,10 @@ locals {
   vault_name              = "acme${replace(local.subscription_short_name, "-", "")}"
 }
 
+moved {
+  from = module.landing_zone[0]
+  to   = module.landing_zone
+}
 module "premium_front_door" {
   source = "git::https://github.com/hmcts/terraform-module-frontdoor.git?ref=DTSPO-13992-test-new-version-of-frontdoor"
 

--- a/components/frontdoor/main.tf
+++ b/components/frontdoor/main.tf
@@ -25,8 +25,8 @@ locals {
 }
 
 moved {
-  from = module.landing_zone[0]
-  to   = module.landing_zone
+  from = module.premium_front_door[0]
+  to   = module.premium_front_door
 }
 module "premium_front_door" {
   source = "git::https://github.com/hmcts/terraform-module-frontdoor.git?ref=DTSPO-13992-test-new-version-of-frontdoor"

--- a/environments/demo/demo.tfvars
+++ b/environments/demo/demo.tfvars
@@ -21,8 +21,6 @@ apim_appgw_backend_pool_fqdns = ["firewall-nonprodi-palo-sdsapimgmtdemo.uksouth.
 apim_appgw_min_capacity       = 1
 apim_appgw_max_capacity       = 2
 
-upgrade_frontdoor = true
-
 frontends = [
   {
     name             = "sds-api-mgmt"

--- a/environments/dev/dev.tfvars
+++ b/environments/dev/dev.tfvars
@@ -20,7 +20,7 @@ hub_app_gw_private_ip_address = ["10.11.72.233"]
 apim_appgw_backend_pool_fqdns = ["firewall-nonprodi-palo-sdsapimgmtdev.uksouth.cloudapp.azure.com"]
 apim_appgw_min_capacity       = 1
 apim_appgw_max_capacity       = 2
-upgrade_frontdoor             = true
+
 frontends = [
 
   {

--- a/environments/ithc/ithc.tfvars
+++ b/environments/ithc/ithc.tfvars
@@ -21,8 +21,6 @@ apim_appgw_backend_pool_fqdns = ["firewall-nonprodi-palo-sdsapimgmtithc.uksouth.
 apim_appgw_min_capacity       = 1
 apim_appgw_max_capacity       = 2
 
-upgrade_frontdoor = true
-
 frontends = [
 
   {

--- a/environments/prod/prod.tfvars
+++ b/environments/prod/prod.tfvars
@@ -22,7 +22,7 @@ ssl_policy = {
 key_vault_subscription        = "5ca62022-6aa2-4cee-aaa7-e7536c8d566c"
 hub_app_gw_private_ip_address = ["10.11.8.200"]
 apim_appgw_backend_pool_fqdns = ["firewall-prod-int-palo-sdsapimgmtprod.uksouth.cloudapp.azure.com"]
-upgrade_frontdoor             = true
+
 frontends = [
   {
     name           = "dts-legacy-apps---certificatedbailiffs"

--- a/environments/sbox/sbox.tfvars
+++ b/environments/sbox/sbox.tfvars
@@ -389,5 +389,3 @@ apim_appgw_exclusions = [
   }
 ]
 
-
-upgrade_frontdoor = true

--- a/environments/stg/stg.tfvars
+++ b/environments/stg/stg.tfvars
@@ -18,7 +18,7 @@ ssl_policy = {
 key_vault_subscription        = "74dacd4f-a248-45bb-a2f0-af700dc4cf68"
 hub_app_gw_private_ip_address = ["10.11.8.212"]
 apim_appgw_backend_pool_fqdns = ["firewall-prod-int-palo-sdsapimgmtstg.uksouth.cloudapp.azure.com"]
-upgrade_frontdoor             = true
+
 frontends = [
 
   {

--- a/environments/test/test.tfvars
+++ b/environments/test/test.tfvars
@@ -20,7 +20,7 @@ hub_app_gw_private_ip_address = ["10.11.72.239"]
 apim_appgw_backend_pool_fqdns = ["firewall-nonprodi-palo-sdsapimgmttest.uksouth.cloudapp.azure.com"]
 apim_appgw_min_capacity       = 1
 apim_appgw_max_capacity       = 2
-upgrade_frontdoor             = true
+
 frontends = [
 
   {

--- a/environments/variable.tf
+++ b/environments/variable.tf
@@ -62,10 +62,7 @@ variable "expiresAfter" {
 variable "autoShutdown" {
   default = false
 }
-variable "upgrade_frontdoor" {
-  type    = bool
-  default = false
-}
+
 variable "ssl_mode" {
   default = "FrontDoor"
 }


### PR DESCRIPTION

### Change description ###

We do not need this upgrade_frontdoor field any more as all the frontdoors are now migrated to premium, we have to change the brach to master as well after merging the DTSPO-13992-test-new-version-of-frontdoor to master on the module.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines

