### PR TITLE
Test hosted_externally in stg and demo fix

### DIFF
--- a/environments/demo/demo.tfvars
+++ b/environments/demo/demo.tfvars
@@ -546,6 +546,7 @@ frontends = [
     product          = "juror-public"
     name             = "juror-public"
     custom_domain    = "juror-public.demo.platform.hmcts.net"
+    dns_zone_name    = "demo.platform.hmcts.net"
     backend_domain   = ["firewall-nonprodi-palo-sdsdemoappgateway.uksouth.cloudapp.azure.com"]
     certificate_name = "wildcard-demo-platform-hmcts-net"
     cache_enabled    = "false"

--- a/environments/stg/stg.tfvars
+++ b/environments/stg/stg.tfvars
@@ -468,7 +468,7 @@ frontends = [
     name              = "staging-trib-land-reg-division"
     mode              = "Prevention"
     custom_domain     = "staging.landregistrationdivision.dsd.io"
-    hosted_externally = false
+    hosted_externally = true
     backend_domain    = ["dts-trib-staging-556942830.eu-west-1.elb.amazonaws.com"]
     shutter_app       = false
 
@@ -508,7 +508,7 @@ frontends = [
     name              = "staging-trib-immigration-svcs"
     mode              = "Prevention"
     custom_domain     = "staging.immigrationservices.dsd.io"
-    hosted_externally = false
+    hosted_externally = true
     backend_domain    = ["dts-trib-staging-556942830.eu-west-1.elb.amazonaws.com"]
     shutter_app       = false
 
@@ -525,7 +525,7 @@ frontends = [
     name              = "staging-trib-info-rights"
     mode              = "Prevention"
     custom_domain     = "staging.informationrights.dsd.io"
-    hosted_externally = false
+    hosted_externally = true
     backend_domain    = ["dts-trib-staging-556942830.eu-west-1.elb.amazonaws.com"]
     shutter_app       = false
 
@@ -557,7 +557,7 @@ frontends = [
     name              = "staging-trib-admin-appeals"
     mode              = "Prevention"
     custom_domain     = "staging.administrativeappeals.dsd.io"
-    hosted_externally = false
+    hosted_externally = true
     backend_domain    = ["dts-trib-staging-556942830.eu-west-1.elb.amazonaws.com"]
     shutter_app       = false
 
@@ -579,7 +579,7 @@ frontends = [
     name              = "staging-trib-care-standards"
     mode              = "Prevention"
     custom_domain     = "staging.carestandards.dsd.io"
-    hosted_externally = false
+    hosted_externally = true
     backend_domain    = ["dts-trib-staging-556942830.eu-west-1.elb.amazonaws.com"]
     shutter_app       = false
 
@@ -611,7 +611,7 @@ frontends = [
     name              = "staging-trib-lands-chamber"
     mode              = "Prevention"
     custom_domain     = "staging.landschamber.dsd.io"
-    hosted_externally = false
+    hosted_externally = true
     backend_domain    = ["dts-trib-staging-556942830.eu-west-1.elb.amazonaws.com"]
     shutter_app       = false
 
@@ -628,7 +628,7 @@ frontends = [
     name              = "staging-trib-finance-tax"
     mode              = "Prevention"
     custom_domain     = "staging.financeandtax.dsd.io"
-    hosted_externally = false
+    hosted_externally = true
     backend_domain    = ["dts-trib-staging-556942830.eu-west-1.elb.amazonaws.com"]
     shutter_app       = false
 
@@ -668,7 +668,7 @@ frontends = [
     name              = "staging-trib-employment-appeals"
     mode              = "Prevention"
     custom_domain     = "staging.employmentappeals.dsd.io"
-    hosted_externally = false
+    hosted_externally = true
     backend_domain    = ["dts-trib-staging-556942830.eu-west-1.elb.amazonaws.com"]
     shutter_app       = false
 
@@ -685,7 +685,7 @@ frontends = [
     name              = "staging-trib-tansport-appeals"
     mode              = "Prevention"
     custom_domain     = "staging.transportappeals.dsd.io"
-    hosted_externally = false
+    hosted_externally = true
     backend_domain    = ["dts-trib-staging-556942830.eu-west-1.elb.amazonaws.com"]
     shutter_app       = false
 

--- a/environments/stg/stg.tfvars
+++ b/environments/stg/stg.tfvars
@@ -801,6 +801,7 @@ frontends = [
   {
     name           = "juror-public"
     custom_domain  = "juror-public.staging.platform.hmcts.net"
+    dns_zone_name  = "staging.platform.hmcts.net"
     backend_domain = ["firewall-prod-int-palo-sdsstg.uksouth.cloudapp.azure.com"]
     cache_enabled  = "false"
     disabled_rules = {}

--- a/environments/stg/stg.tfvars
+++ b/environments/stg/stg.tfvars
@@ -699,12 +699,12 @@ frontends = [
     ]
   },
   {
-    name           = "staging-trib-cicap"
-    mode           = "Prevention"
-    custom_domain  = "staging.cicap.dsd.io"
-    dns_zone_name  = "cicap.dsd.io"
-    backend_domain = ["dts-trib-staging-556942830.eu-west-1.elb.amazonaws.com"]
-    shutter_app    = false
+    name              = "staging-trib-cicap"
+    mode              = "Prevention"
+    custom_domain     = "staging.cicap.dsd.io"
+    hosted_externally = true
+    backend_domain    = ["dts-trib-staging-556942830.eu-west-1.elb.amazonaws.com"]
+    shutter_app       = false
 
 
     global_exclusions = [

--- a/environments/stg/stg.tfvars
+++ b/environments/stg/stg.tfvars
@@ -528,7 +528,6 @@ frontends = [
     mode              = "Prevention"
     custom_domain     = "staging.informationrights.dsd.io"
     hosted_externally = true
-    dns_zone_name     = "informationrights.dsd.io"
     backend_domain    = ["dts-trib-staging-556942830.eu-west-1.elb.amazonaws.com"]
     shutter_app       = false
 

--- a/environments/stg/stg.tfvars
+++ b/environments/stg/stg.tfvars
@@ -469,7 +469,6 @@ frontends = [
     mode              = "Prevention"
     custom_domain     = "staging.landregistrationdivision.dsd.io"
     hosted_externally = true
-    dns_zone_name     = "landregistrationdivision.dsd.io"
     backend_domain    = ["dts-trib-staging-556942830.eu-west-1.elb.amazonaws.com"]
     shutter_app       = false
 
@@ -510,7 +509,6 @@ frontends = [
     mode              = "Prevention"
     custom_domain     = "staging.immigrationservices.dsd.io"
     hosted_externally = true
-    dns_zone_name     = "immigrationservices.dsd.io"
     backend_domain    = ["dts-trib-staging-556942830.eu-west-1.elb.amazonaws.com"]
     shutter_app       = false
 
@@ -560,7 +558,6 @@ frontends = [
     mode              = "Prevention"
     custom_domain     = "staging.administrativeappeals.dsd.io"
     hosted_externally = true
-    dns_zone_name     = "administrativeappeals.dsd.io"
     backend_domain    = ["dts-trib-staging-556942830.eu-west-1.elb.amazonaws.com"]
     shutter_app       = false
 
@@ -583,7 +580,6 @@ frontends = [
     mode              = "Prevention"
     custom_domain     = "staging.carestandards.dsd.io"
     hosted_externally = true
-    dns_zone_name     = "carestandards.dsd.io"
     backend_domain    = ["dts-trib-staging-556942830.eu-west-1.elb.amazonaws.com"]
     shutter_app       = false
 
@@ -616,7 +612,6 @@ frontends = [
     mode              = "Prevention"
     custom_domain     = "staging.landschamber.dsd.io"
     hosted_externally = true
-    dns_zone_name     = "landschamber.dsd.io"
     backend_domain    = ["dts-trib-staging-556942830.eu-west-1.elb.amazonaws.com"]
     shutter_app       = false
 
@@ -634,7 +629,6 @@ frontends = [
     mode              = "Prevention"
     custom_domain     = "staging.financeandtax.dsd.io"
     hosted_externally = true
-    dns_zone_name     = "financeandtax.dsd.io"
     backend_domain    = ["dts-trib-staging-556942830.eu-west-1.elb.amazonaws.com"]
     shutter_app       = false
 
@@ -675,7 +669,6 @@ frontends = [
     mode              = "Prevention"
     custom_domain     = "staging.employmentappeals.dsd.io"
     hosted_externally = true
-    dns_zone_name     = "employmentappeals.dsd.io"
     backend_domain    = ["dts-trib-staging-556942830.eu-west-1.elb.amazonaws.com"]
     shutter_app       = false
 
@@ -693,7 +686,6 @@ frontends = [
     mode              = "Prevention"
     custom_domain     = "staging.transportappeals.dsd.io"
     hosted_externally = true
-    dns_zone_name     = "transportappeals.dsd.io"
     backend_domain    = ["dts-trib-staging-556942830.eu-west-1.elb.amazonaws.com"]
     shutter_app       = false
 
@@ -711,7 +703,6 @@ frontends = [
     mode              = "Prevention"
     custom_domain     = "staging.cicap.dsd.io"
     hosted_externally = true
-    dns_zone_name     = "cicap.dsd.io"
     backend_domain    = ["dts-trib-staging-556942830.eu-west-1.elb.amazonaws.com"]
     shutter_app       = false
 

--- a/environments/stg/stg.tfvars
+++ b/environments/stg/stg.tfvars
@@ -469,6 +469,7 @@ frontends = [
     mode              = "Prevention"
     custom_domain     = "staging.landregistrationdivision.dsd.io"
     hosted_externally = true
+    dns_zone_name     = "landregistrationdivision.dsd.io"
     backend_domain    = ["dts-trib-staging-556942830.eu-west-1.elb.amazonaws.com"]
     shutter_app       = false
 
@@ -509,6 +510,7 @@ frontends = [
     mode              = "Prevention"
     custom_domain     = "staging.immigrationservices.dsd.io"
     hosted_externally = true
+    dns_zone_name     = "immigrationservices.dsd.io"
     backend_domain    = ["dts-trib-staging-556942830.eu-west-1.elb.amazonaws.com"]
     shutter_app       = false
 
@@ -526,6 +528,7 @@ frontends = [
     mode              = "Prevention"
     custom_domain     = "staging.informationrights.dsd.io"
     hosted_externally = true
+    dns_zone_name     = "informationrights.dsd.io"
     backend_domain    = ["dts-trib-staging-556942830.eu-west-1.elb.amazonaws.com"]
     shutter_app       = false
 
@@ -558,6 +561,7 @@ frontends = [
     mode              = "Prevention"
     custom_domain     = "staging.administrativeappeals.dsd.io"
     hosted_externally = true
+    dns_zone_name     = "administrativeappeals.dsd.io"
     backend_domain    = ["dts-trib-staging-556942830.eu-west-1.elb.amazonaws.com"]
     shutter_app       = false
 
@@ -580,6 +584,7 @@ frontends = [
     mode              = "Prevention"
     custom_domain     = "staging.carestandards.dsd.io"
     hosted_externally = true
+    dns_zone_name     = "carestandards.dsd.io"
     backend_domain    = ["dts-trib-staging-556942830.eu-west-1.elb.amazonaws.com"]
     shutter_app       = false
 
@@ -612,6 +617,7 @@ frontends = [
     mode              = "Prevention"
     custom_domain     = "staging.landschamber.dsd.io"
     hosted_externally = true
+    dns_zone_name     = "landschamber.dsd.io"
     backend_domain    = ["dts-trib-staging-556942830.eu-west-1.elb.amazonaws.com"]
     shutter_app       = false
 
@@ -629,6 +635,7 @@ frontends = [
     mode              = "Prevention"
     custom_domain     = "staging.financeandtax.dsd.io"
     hosted_externally = true
+    dns_zone_name     = "financeandtax.dsd.io"
     backend_domain    = ["dts-trib-staging-556942830.eu-west-1.elb.amazonaws.com"]
     shutter_app       = false
 
@@ -669,6 +676,7 @@ frontends = [
     mode              = "Prevention"
     custom_domain     = "staging.employmentappeals.dsd.io"
     hosted_externally = true
+    dns_zone_name     = "employmentappeals.dsd.io"
     backend_domain    = ["dts-trib-staging-556942830.eu-west-1.elb.amazonaws.com"]
     shutter_app       = false
 
@@ -686,6 +694,7 @@ frontends = [
     mode              = "Prevention"
     custom_domain     = "staging.transportappeals.dsd.io"
     hosted_externally = true
+    dns_zone_name     = "transportappeals.dsd.io"
     backend_domain    = ["dts-trib-staging-556942830.eu-west-1.elb.amazonaws.com"]
     shutter_app       = false
 
@@ -703,6 +712,7 @@ frontends = [
     mode              = "Prevention"
     custom_domain     = "staging.cicap.dsd.io"
     hosted_externally = true
+    dns_zone_name     = "cicap.dsd.io"
     backend_domain    = ["dts-trib-staging-556942830.eu-west-1.elb.amazonaws.com"]
     shutter_app       = false
 

--- a/environments/stg/stg.tfvars
+++ b/environments/stg/stg.tfvars
@@ -465,12 +465,12 @@ frontends = [
     cache_enabled    = "false"
   },
   {
-    name           = "staging-trib-land-reg-division"
-    mode           = "Prevention"
-    custom_domain  = "staging.landregistrationdivision.dsd.io"
-    dns_zone_name  = "landregistrationdivision.dsd.io"
-    backend_domain = ["dts-trib-staging-556942830.eu-west-1.elb.amazonaws.com"]
-    shutter_app    = false
+    name              = "staging-trib-land-reg-division"
+    mode              = "Prevention"
+    custom_domain     = "staging.landregistrationdivision.dsd.io"
+    hosted_externally = true
+    backend_domain    = ["dts-trib-staging-556942830.eu-west-1.elb.amazonaws.com"]
+    shutter_app       = false
 
 
     global_exclusions = [
@@ -505,12 +505,12 @@ frontends = [
     ]
   },
   {
-    name           = "staging-trib-immigration-svcs"
-    mode           = "Prevention"
-    custom_domain  = "staging.immigrationservices.dsd.io"
-    dns_zone_name  = "immigrationservices.dsd.io"
-    backend_domain = ["dts-trib-staging-556942830.eu-west-1.elb.amazonaws.com"]
-    shutter_app    = false
+    name              = "staging-trib-immigration-svcs"
+    mode              = "Prevention"
+    custom_domain     = "staging.immigrationservices.dsd.io"
+    hosted_externally = true
+    backend_domain    = ["dts-trib-staging-556942830.eu-west-1.elb.amazonaws.com"]
+    shutter_app       = false
 
 
     global_exclusions = [
@@ -522,12 +522,12 @@ frontends = [
     ]
   },
   {
-    name           = "staging-trib-info-rights"
-    mode           = "Prevention"
-    custom_domain  = "staging.informationrights.dsd.io"
-    dns_zone_name  = "immigrationservices.dsd.io"
-    backend_domain = ["dts-trib-staging-556942830.eu-west-1.elb.amazonaws.com"]
-    shutter_app    = false
+    name              = "staging-trib-info-rights"
+    mode              = "Prevention"
+    custom_domain     = "staging.informationrights.dsd.io"
+    hosted_externally = true
+    backend_domain    = ["dts-trib-staging-556942830.eu-west-1.elb.amazonaws.com"]
+    shutter_app       = false
 
 
     global_exclusions = [
@@ -554,12 +554,12 @@ frontends = [
     ]
   },
   {
-    name           = "staging-trib-admin-appeals"
-    mode           = "Prevention"
-    custom_domain  = "staging.administrativeappeals.dsd.io"
-    dns_zone_name  = "administrativeappeals.dsd.io"
-    backend_domain = ["dts-trib-staging-556942830.eu-west-1.elb.amazonaws.com"]
-    shutter_app    = false
+    name              = "staging-trib-admin-appeals"
+    mode              = "Prevention"
+    custom_domain     = "staging.administrativeappeals.dsd.io"
+    hosted_externally = true
+    backend_domain    = ["dts-trib-staging-556942830.eu-west-1.elb.amazonaws.com"]
+    shutter_app       = false
 
 
     global_exclusions = [
@@ -576,12 +576,12 @@ frontends = [
     ]
   },
   {
-    name           = "staging-trib-care-standards"
-    mode           = "Prevention"
-    custom_domain  = "staging.carestandards.dsd.io"
-    dns_zone_name  = "carestandards.dsd.io"
-    backend_domain = ["dts-trib-staging-556942830.eu-west-1.elb.amazonaws.com"]
-    shutter_app    = false
+    name              = "staging-trib-care-standards"
+    mode              = "Prevention"
+    custom_domain     = "staging.carestandards.dsd.io"
+    hosted_externally = true
+    backend_domain    = ["dts-trib-staging-556942830.eu-west-1.elb.amazonaws.com"]
+    shutter_app       = false
 
 
     global_exclusions = [
@@ -608,12 +608,12 @@ frontends = [
     ]
   },
   {
-    name           = "staging-trib-lands-chamber"
-    mode           = "Prevention"
-    custom_domain  = "staging.landschamber.dsd.io"
-    dns_zone_name  = "landschamber.dsd.io"
-    backend_domain = ["dts-trib-staging-556942830.eu-west-1.elb.amazonaws.com"]
-    shutter_app    = false
+    name              = "staging-trib-lands-chamber"
+    mode              = "Prevention"
+    custom_domain     = "staging.landschamber.dsd.io"
+    hosted_externally = true
+    backend_domain    = ["dts-trib-staging-556942830.eu-west-1.elb.amazonaws.com"]
+    shutter_app       = false
 
 
     global_exclusions = [
@@ -625,12 +625,12 @@ frontends = [
     ]
   },
   {
-    name           = "staging-trib-finance-tax"
-    mode           = "Prevention"
-    custom_domain  = "staging.financeandtax.dsd.io"
-    dns_zone_name  = "financeandtax.dsd.io"
-    backend_domain = ["dts-trib-staging-556942830.eu-west-1.elb.amazonaws.com"]
-    shutter_app    = false
+    name              = "staging-trib-finance-tax"
+    mode              = "Prevention"
+    custom_domain     = "staging.financeandtax.dsd.io"
+    hosted_externally = true
+    backend_domain    = ["dts-trib-staging-556942830.eu-west-1.elb.amazonaws.com"]
+    shutter_app       = false
 
 
     disabled_rules = {
@@ -665,12 +665,12 @@ frontends = [
     ]
   },
   {
-    name           = "staging-trib-employment-appeals"
-    mode           = "Prevention"
-    custom_domain  = "staging.employmentappeals.dsd.io"
-    dns_zone_name  = "employmentappeals.dsd.io"
-    backend_domain = ["dts-trib-staging-556942830.eu-west-1.elb.amazonaws.com"]
-    shutter_app    = false
+    name              = "staging-trib-employment-appeals"
+    mode              = "Prevention"
+    custom_domain     = "staging.employmentappeals.dsd.io"
+    hosted_externally = true
+    backend_domain    = ["dts-trib-staging-556942830.eu-west-1.elb.amazonaws.com"]
+    shutter_app       = false
 
 
     global_exclusions = [
@@ -682,12 +682,12 @@ frontends = [
     ]
   },
   {
-    name           = "staging-trib-tansport-appeals"
-    mode           = "Prevention"
-    custom_domain  = "staging.transportappeals.dsd.io"
-    dns_zone_name  = "transportappeals.dsd.io"
-    backend_domain = ["dts-trib-staging-556942830.eu-west-1.elb.amazonaws.com"]
-    shutter_app    = false
+    name              = "staging-trib-tansport-appeals"
+    mode              = "Prevention"
+    custom_domain     = "staging.transportappeals.dsd.io"
+    hosted_externally = true
+    backend_domain    = ["dts-trib-staging-556942830.eu-west-1.elb.amazonaws.com"]
+    shutter_app       = false
 
 
     global_exclusions = [

--- a/environments/stg/stg.tfvars
+++ b/environments/stg/stg.tfvars
@@ -468,7 +468,7 @@ frontends = [
     name              = "staging-trib-land-reg-division"
     mode              = "Prevention"
     custom_domain     = "staging.landregistrationdivision.dsd.io"
-    hosted_externally = true
+    hosted_externally = false
     backend_domain    = ["dts-trib-staging-556942830.eu-west-1.elb.amazonaws.com"]
     shutter_app       = false
 
@@ -508,7 +508,7 @@ frontends = [
     name              = "staging-trib-immigration-svcs"
     mode              = "Prevention"
     custom_domain     = "staging.immigrationservices.dsd.io"
-    hosted_externally = true
+    hosted_externally = false
     backend_domain    = ["dts-trib-staging-556942830.eu-west-1.elb.amazonaws.com"]
     shutter_app       = false
 
@@ -525,7 +525,7 @@ frontends = [
     name              = "staging-trib-info-rights"
     mode              = "Prevention"
     custom_domain     = "staging.informationrights.dsd.io"
-    hosted_externally = true
+    hosted_externally = false
     backend_domain    = ["dts-trib-staging-556942830.eu-west-1.elb.amazonaws.com"]
     shutter_app       = false
 
@@ -557,7 +557,7 @@ frontends = [
     name              = "staging-trib-admin-appeals"
     mode              = "Prevention"
     custom_domain     = "staging.administrativeappeals.dsd.io"
-    hosted_externally = true
+    hosted_externally = false
     backend_domain    = ["dts-trib-staging-556942830.eu-west-1.elb.amazonaws.com"]
     shutter_app       = false
 
@@ -579,7 +579,7 @@ frontends = [
     name              = "staging-trib-care-standards"
     mode              = "Prevention"
     custom_domain     = "staging.carestandards.dsd.io"
-    hosted_externally = true
+    hosted_externally = false
     backend_domain    = ["dts-trib-staging-556942830.eu-west-1.elb.amazonaws.com"]
     shutter_app       = false
 
@@ -611,7 +611,7 @@ frontends = [
     name              = "staging-trib-lands-chamber"
     mode              = "Prevention"
     custom_domain     = "staging.landschamber.dsd.io"
-    hosted_externally = true
+    hosted_externally = false
     backend_domain    = ["dts-trib-staging-556942830.eu-west-1.elb.amazonaws.com"]
     shutter_app       = false
 
@@ -628,7 +628,7 @@ frontends = [
     name              = "staging-trib-finance-tax"
     mode              = "Prevention"
     custom_domain     = "staging.financeandtax.dsd.io"
-    hosted_externally = true
+    hosted_externally = false
     backend_domain    = ["dts-trib-staging-556942830.eu-west-1.elb.amazonaws.com"]
     shutter_app       = false
 
@@ -668,7 +668,7 @@ frontends = [
     name              = "staging-trib-employment-appeals"
     mode              = "Prevention"
     custom_domain     = "staging.employmentappeals.dsd.io"
-    hosted_externally = true
+    hosted_externally = false
     backend_domain    = ["dts-trib-staging-556942830.eu-west-1.elb.amazonaws.com"]
     shutter_app       = false
 
@@ -685,7 +685,7 @@ frontends = [
     name              = "staging-trib-tansport-appeals"
     mode              = "Prevention"
     custom_domain     = "staging.transportappeals.dsd.io"
-    hosted_externally = true
+    hosted_externally = false
     backend_domain    = ["dts-trib-staging-556942830.eu-west-1.elb.amazonaws.com"]
     shutter_app       = false
 


### PR DESCRIPTION
### Change description ###
Test hosted_externally in stg
- Added a fix to resolve demo pipeline as well

Fixes error in pipeline for stg_frontdoor, that DNS zones we don't own
`##[error]Terraform command 'plan' failed with exit code '1'.
##[error]╷
│ Error: Dns Zone (Subscription: "ed302caf-ec27-4c64-a05e-85731c3ce90e"
│ Resource Group Name: "reformmgmtrg"
│ Dns Zone Name: "carestandards.dsd.io") was not found`

