### PR TITLE
add apim test and depend prod on stg apim

### DIFF
--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -135,7 +135,7 @@ parameters:
         pipeline_tests: false
       - deployment: "apim"
         environment: "prod"
-        dependsOn: "sbox_apim"
+        dependsOn: "stg_apim"
         pipeline_tests: false
       - deployment: "apim"
         environment: "test"

--- a/scripts/apim.test.ts
+++ b/scripts/apim.test.ts
@@ -2,35 +2,26 @@ import { fail } from "assert";
 
 import axios, { AxiosResponse } from "axios";
 
-// APP_NAME will be set to the value of plum or toffee
-const APP_NAME =
-  process.env.APP_NAME
-
-
-// TEST_URL will be set to ${product}.${environment}.platform.hmcts.net
-const TEST_URL =
-  process.env.TEST_URL
+// TEST_URL will be set to ${APIM_NAME}.${environment}.platform.hmcts.net
+const APIM_TEST_URL =
+  process.env.APIM_TEST_URL
 
 describe("Test Name", () => {
-  describe(`Test case`, () => {
-    test(`Success message`, async () => {
+  describe(`Test case ${APIM_TEST_URL}`, () => {
+    test(`apim is healthy (${APIM_TEST_URL}/health/liveness)`, async () => {
       try {
+        const url = `https://${APIM_TEST_URL}/health/liveness`;
+        const response: AxiosResponse = await axios
+          .request({
+            method: "GET",
+            url: url,
+            headers: {
+              Accept: "application/json, text/plain, */*",
+              "Accept-Encoding": "gzip",
+            },
+          })
 
-        // Placeholder test to check TEST_URL is defined
-        expect(TEST_URL).toBeDefined();
-
-        // Example test: perform a GET request against your applications liveness endpoint
-        // const url = `https://${TEST_URL}/health/liveness`;
-        // const response: AxiosResponse = await axios
-        //   .request({
-        //     method: "GET",
-        //     url: url,
-        //     headers: {
-        //       "Accept-Encoding": "gzip",
-        //     },
-        //   })
-        // Example response: expect the HTTP status code 200
-        // expect(response.status).toBe(200);
+        expect(response.status).toBe(200);
       } catch(error) {
         fail(error.stack);
       }


### PR DESCRIPTION
### Change description ###
- Updated APIM Prod stage to depend_on APIM Stg/AAT
- Updated [apim.test.ts](https://github.com/hmcts/azure-platform-terraform/pull/1910/files#diff-852523a669ece4bcd3cf4cccf2220690596c9387853a7882a78524f7bd971c0e)to a valid test

Testing:
- Did remove condition to allow tests to run on non `main` branch
[Successful test](https://dev.azure.com/hmcts/PlatformOperations/_build/results?buildId=491738&view=results)
[Failed test](https://dev.azure.com/hmcts/PlatformOperations/_build/results?buildId=491731&view=results)
