### PR TITLE
Removed listener suffix properties from app gateway config

### DIFF
--- a/environments/demo/apim_appgw_config.yaml
+++ b/environments/demo/apim_appgw_config.yaml
@@ -15,5 +15,3 @@ gateways:
         ssl_certificate_name: wildcard-demo-platform-hmcts-net
         host_name_suffix: demo.platform.hmcts.net
         ssl_host_name_suffix: demo.platform.hmcts.net
-        listener_host_name_suffix: demo.platform.hmcts.net
-        listener_ssl_host_name_suffix: demo.platform.hmcts.net

--- a/environments/dev/apim_appgw_config.yaml
+++ b/environments/dev/apim_appgw_config.yaml
@@ -15,5 +15,3 @@ gateways:
         ssl_certificate_name: wildcard-dev-platform-hmcts-net
         host_name_suffix: dev.platform.hmcts.net
         ssl_host_name_suffix: dev.platform.hmcts.net
-        listener_host_name_suffix: dev.platform.hmcts.net
-        listener_ssl_host_name_suffix: dev.platform.hmcts.net

--- a/environments/ithc/apim_appgw_config.yaml
+++ b/environments/ithc/apim_appgw_config.yaml
@@ -15,5 +15,3 @@ gateways:
         ssl_certificate_name: wildcard-ithc-platform-hmcts-net
         host_name_suffix: ithc.platform.hmcts.net
         ssl_host_name_suffix: ithc.platform.hmcts.net
-        listener_host_name_suffix: ithc.platform.hmcts.net
-        listener_ssl_host_name_suffix: ithc.platform.hmcts.net

--- a/environments/prod/apim_appgw_config.yaml
+++ b/environments/prod/apim_appgw_config.yaml
@@ -15,5 +15,3 @@ gateways:
         ssl_certificate_name: wildcard-platform-hmcts-net
         host_name_suffix: platform.hmcts.net
         ssl_host_name_suffix: platform.hmcts.net
-        listener_host_name_suffix: platform.hmcts.net
-        listener_ssl_host_name_suffix: platform.hmcts.net

--- a/environments/sbox/apim_appgw_config.yaml
+++ b/environments/sbox/apim_appgw_config.yaml
@@ -15,5 +15,3 @@ gateways:
         ssl_certificate_name: wildcard-sandbox-platform-hmcts-net
         host_name_suffix: sandbox.platform.hmcts.net
         ssl_host_name_suffix: sandbox.platform.hmcts.net
-        listener_host_name_suffix: sandbox.platform.hmcts.net
-        listener_ssl_host_name_suffix: sandbox.platform.hmcts.net

--- a/environments/stg/apim_appgw_config.yaml
+++ b/environments/stg/apim_appgw_config.yaml
@@ -15,5 +15,3 @@ gateways:
         ssl_certificate_name: wildcard-staging-platform-hmcts-net
         host_name_suffix: stg.platform.hmcts.net
         ssl_host_name_suffix: staging.platform.hmcts.net
-        listener_host_name_suffix: stg.platform.hmcts.net
-        listener_ssl_host_name_suffix: staging.platform.hmcts.net

--- a/environments/test/apim_appgw_config.yaml
+++ b/environments/test/apim_appgw_config.yaml
@@ -15,5 +15,3 @@ gateways:
         ssl_certificate_name: wildcard-test-platform-hmcts-net
         host_name_suffix: test.platform.hmcts.net
         ssl_host_name_suffix: test.platform.hmcts.net
-        listener_host_name_suffix: test.platform.hmcts.net
-        listener_ssl_host_name_suffix: test.platform.hmcts.net


### PR DESCRIPTION
### Jira link (if applicable)
N/A


### Change description ###
Removed listener_host_name_suffix and listener_ssl_host_name_suffix properties from application gateway configuration files.  These are no longer needed due to changes to terraform-module-apim-application-gateway (see https://github.com/hmcts/terraform-module-apim-application-gateway/pull/21).

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [no] Does this PR introduce a breaking change
