### PR TITLE
feat: specify timeout for LibraGoB

### DIFF
--- a/components/backendappgateway/main.tf
+++ b/components/backendappgateway/main.tf
@@ -20,7 +20,7 @@ locals {
 }
 
 module "backendappgateway" {
-  source = "git::https://github.com/hmcts/terraform-module-application-backend.git?ref=master"
+  source = "git::https://github.com/hmcts/terraform-module-application-backend.git?ref=feat%2Fspecify-timeout"
 
   yaml_path = "${path.cwd}/../../environments/${var.env}/backend_lb_config.yaml"
 

--- a/components/backendappgateway/main.tf
+++ b/components/backendappgateway/main.tf
@@ -20,7 +20,7 @@ locals {
 }
 
 module "backendappgateway" {
-  source = "git::https://github.com/hmcts/terraform-module-application-backend.git?ref=feat%2Fspecify-timeout"
+  source = "git::https://github.com/hmcts/terraform-module-application-backend.git?ref=master"
 
   yaml_path = "${path.cwd}/../../environments/${var.env}/backend_lb_config.yaml"
 

--- a/environments/prod/backend_lb_config.yaml
+++ b/environments/prod/backend_lb_config.yaml
@@ -58,6 +58,7 @@ gateways:
         host_name_prefix: cloudgobgateway
         ssl_enabled: true
         health_path_override: "/services/themisgatewayapi?wsdl"
+        request_timeout: 60
      # Pre-Recorded Evidence
       - product: pre
         component: portal

--- a/environments/prod/backend_lb_config.yaml
+++ b/environments/prod/backend_lb_config.yaml
@@ -58,7 +58,7 @@ gateways:
         host_name_prefix: cloudgobgateway
         ssl_enabled: true
         health_path_override: "/services/themisgatewayapi?wsdl"
-        request_timeout: 60
+        request_timeout: 120
      # Pre-Recorded Evidence
       - product: pre
         component: portal


### PR DESCRIPTION
### Jira link (if applicable)
N/A


### Change description ###
Sometimes when a large amount of processing is requested by the On-Prem GoB Application in Azure the application can take >60 seconds to respond.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
