### PR TITLE
Update dev.tfvars

### DIFF
--- a/environments/dev/dev.tfvars
+++ b/environments/dev/dev.tfvars
@@ -301,6 +301,8 @@ frontends = [
     ]
   },
   {
+    name           = "vh-video-web-pr-2142" # TO DO: REMOVE AFTER TESTING
+    custom_domain  = "vh-video-web-pr-2142.dev.platform.hmcts.net"
     name           = "vh-admin-web"
     custom_domain  = "vh-admin-web.dev.platform.hmcts.net"
     dns_zone_name  = "dev.platform.hmcts.net"


### PR DESCRIPTION
Make PR url outside VPN for dev to test

### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/VIH-10699

### Change description ###
In Video API, we specify a callback url which Kinly send their events to. For testing a ticket I’ve had to change this callback url to point at the above PR instance, however this url won’t be reachable by Kinly/Pexip

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


- **dev.tfvars**:
  - Added a new frontend with the name \"vh-video-web-pr-2142\" and custom domain \"vh-video-web-pr-2142.dev.platform.hmcts.net\".