### PR TITLE
add pipeline timeout for apim upgrade

### DIFF
--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -189,6 +189,8 @@ variables:
   - name: tfInitSub
     value: "04d27a32-7a07-48b3-95b8-3c8691e1a263"
   - template: vars/input-variables.yaml@cnp-azuredevops-libraries
+  - name: timeoutInMinutes
+    value: 90
 
 stages:
   - stage: Precheck
@@ -196,6 +198,7 @@ stages:
       - job: Validate
         pool:
           vmImage: ${{ variables.agentPool }}
+        timeoutInMinutes: ${{ variables.timeoutInMinutes }}
         steps:
           - template: steps/terraform-precheck.yaml@cnp-azuredevops-libraries
             parameters:
@@ -216,6 +219,7 @@ stages:
           - job: TerraformPlanApply
             pool:
               vmImage: ${{ variables.agentPool }}
+            timeoutInMinutes: ${{ variables.timeoutInMinutes }}
             steps:
               - template: steps/terraform.yaml@cnp-azuredevops-libraries
                 parameters:
@@ -232,6 +236,7 @@ stages:
           - job: PipelineTests
             pool:
               vmImage: ${{ variables.agentPool }}
+            timeoutInMinutes: ${{ variables.timeoutInMinutes }}
             dependsOn: TerraformPlanApply
             condition: and(succeeded(), eq(variables['isMain'], true), eq('${{ parameter.pipeline_tests }}', 'true'))
             steps:


### PR DESCRIPTION
### Jira link (if applicable)

### Change description ###
added pipeline time limit variable added to precheck, steps and pipeline tests

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


- Modified azure-pipelines.yaml
- Added a timeoutInMinutes variable with a value of 90
- Updated the Validate, TerraformPlanApply, and PipelineTests jobs to include a timeoutInMinutes parameter referencing the newly added variable