### PR TITLE
migrate sds apim demo back to original resources

### DIFF
--- a/environments/demo/demo.tfvars
+++ b/environments/demo/demo.tfvars
@@ -16,7 +16,7 @@ ssl_policy = {
 }
 
 migration_variables = {
-  trigger_migration            = true
+  trigger_migration            = false
   trigger_migration_temp_pip   = true
   temp_subnet_address_prefixes = "10.51.99.0/24"
 }

--- a/environments/ithc/ithc.tfvars
+++ b/environments/ithc/ithc.tfvars
@@ -15,12 +15,6 @@ ssl_policy = {
   min_protocol_version = "TLSv1_2"
 }
 
-migration_variables = {
-  trigger_migration            = false
-  trigger_migration_temp_pip   = false
-  temp_subnet_address_prefixes = "10.143.35.0/24"
-}
-
 key_vault_subscription        = "ba71a911-e0d6-4776-a1a6-079af1df7139"
 hub_app_gw_private_ip_address = ["10.11.72.236"]
 apim_appgw_backend_pool_fqdns = ["firewall-nonprodi-palo-sdsapimgmtithc.uksouth.cloudapp.azure.com"]


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-17760

### Change description ###
migrate sds apim demo back to original resources
remove ithc vars no longer needed

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change




## 🤖AEP PR SUMMARY🤖


- `environments/demo/demo.tfvars`:
  - Changed `trigger_migration` from `true` to `false`.
  - Updated `trigger_migration_temp_pip` to `true`.
  - Updated `temp_subnet_address_prefixes` to `\"10.51.99.0/24\"`.

- `environments/ithc/ithc.tfvars`:
  - Removed `migration_variables` block.
  - Updated `min_protocol_version` to `\"TLSv1_2\"`.