### PR TITLE
Fix vh-video-web-pr-2142.dev.platform.hmcts record

### DIFF
--- a/environments/dev/dev.tfvars
+++ b/environments/dev/dev.tfvars
@@ -301,10 +301,24 @@ frontends = [
     ]
   },
   {
-    name           = "vh-video-web-pr-2142" # TO DO: REMOVE AFTER TESTING
-    custom_domain  = "vh-video-web-pr-2142.dev.platform.hmcts.net"
     name           = "vh-admin-web"
     custom_domain  = "vh-admin-web.dev.platform.hmcts.net"
+    dns_zone_name  = "dev.platform.hmcts.net"
+    backend_domain = ["firewall-nonprodi-palo-sdsdev.uksouth.cloudapp.azure.com"]
+    disabled_rules = {}
+    cache_enabled  = "false"
+
+    global_exclusions = [
+      {
+        match_variable = "QueryStringArgNames"
+        operator       = "Equals"
+        selector       = "code"
+      }
+    ]
+  },
+  {
+    name           = "vh-video-web-pr-2142" # TO DO: REMOVE AFTER TESTING
+    custom_domain  = "vh-video-web-pr-2142.dev.platform.hmcts.net"
     dns_zone_name  = "dev.platform.hmcts.net"
     backend_domain = ["firewall-nonprodi-palo-sdsdev.uksouth.cloudapp.azure.com"]
     disabled_rules = {}


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DTSPO-17814

### Change description ###

Fixes DNS entry for vh-video-web-pr-2142.dev.platform.hmcts

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


- Modified `dev.tfvars`:
  - Removed `vh-video-web-pr-2142` with custom domain `vh-video-web-pr-2142.dev.platform.hmcts.net`.
  - Added `vh-video-web-pr-2142` with custom domain `vh-video-web-pr-2142.dev.platform.hmcts.net`, backend domain, disabled rules, cache enabled, and global exclusions.