### PR TITLE
DTSPO-17762-sds-apim-test-upgrade-pt2

### DIFF
--- a/environments/demo/demo.tfvars
+++ b/environments/demo/demo.tfvars
@@ -15,12 +15,6 @@ ssl_policy = {
   min_protocol_version = "TLSv1_2"
 }
 
-migration_variables = {
-  trigger_migration            = false
-  trigger_migration_temp_pip   = false
-  temp_subnet_address_prefixes = "10.51.99.0/24"
-}
-
 key_vault_subscription        = "c68a4bed-4c3d-4956-af51-4ae164c1957c"
 hub_app_gw_private_ip_address = ["10.11.72.230"]
 apim_appgw_backend_pool_fqdns = ["firewall-nonprodi-palo-sdsapimgmtdemo.uksouth.cloudapp.azure.com"]

--- a/environments/test/test.tfvars
+++ b/environments/test/test.tfvars
@@ -16,7 +16,7 @@ ssl_policy = {
 }
 
 migration_variables = {
-  trigger_migration            = true
+  trigger_migration            = false
   trigger_migration_temp_pip   = true
   temp_subnet_address_prefixes = "10.141.35.0/24"
 }


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-17762

### Change description ###
trigger migration of sds apim test to original resources

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


### demo.tfvars
- Removed the `migration_variables` block with the fields `trigger_migration`, `trigger_migration_temp_pip`, and `temp_subnet_address_prefixes`.
- Updated the value of `hub_app_gw_private_ip_address` to `[\"10.11.72.230\"]`.
- Updated the value of `apim_appgw_backend_pool_fqdns` to `[\"firewall-nonprodi-palo-sdsapimgmtdemo.uksouth.cloudapp.azure.com\"]`.
- Updated the value of `key_vault_subscription` to `\"c68a4bed-4c3d-4956-af51-4ae164c1957c\"`.

### test.tfvars
- Changed the value of `trigger_migration` from `true` to `false`.
- Changed the value of `trigger_migration_temp_pip` to `true`.
- Updated the value of `temp_subnet_address_prefixes` to `\"10.141.35.0/24\"`.