### PR TITLE
revert pipeline timeout back to 60 minutes

### DIFF
--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -190,7 +190,7 @@ variables:
     value: "04d27a32-7a07-48b3-95b8-3c8691e1a263"
   - template: vars/input-variables.yaml@cnp-azuredevops-libraries
   - name: timeoutInMinutes
-    value: 90
+    value: 60
 
 stages:
   - stage: Precheck


### PR DESCRIPTION
### Jira link (if applicable)


### Change description ###
updated pipeline timeout from 90 -> 60 minutes

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


- **azure-pipelines.yaml**
  - Updated the `timeoutInMinutes` variable value from 90 to 60.