### PR TITLE
PUB-2503 - Updated exclusion for false positive CaTH

### DIFF
--- a/environments/stg/stg.tfvars
+++ b/environments/stg/stg.tfvars
@@ -299,6 +299,11 @@ frontends = [
         match_variable = "RequestCookieNames"
         operator       = "Equals"
         selector       = "dtSa"
+      },
+      {
+        match_variable = "QueryStringArgNames"
+        operator       = "Equals"
+        selector       = "csrf_token"
       }
     ]
   },
@@ -382,6 +387,11 @@ frontends = [
         match_variable = "RequestCookieNames"
         operator       = "Equals"
         selector       = "dtSa"
+      },
+      {
+        match_variable = "QueryStringArgNames"
+        operator       = "Equals"
+        selector       = "csrf_token"
       }
     ]
   },


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/PUB-2503

### Change description ###

Updated exclusion for false positive for CaTH

## 🤖AEP PR SUMMARY🤖


### environments/stg/stg.tfvars
- Added a new match_variable, operator, and selector for the frontends in the stg.tfvars file.csrf_token has been added as a query string argument name.