### PR TITLE
DTSPO-18453: min/max set to 1/2 for stg apim_appgw

### DIFF
--- a/environments/stg/stg.tfvars
+++ b/environments/stg/stg.tfvars
@@ -23,6 +23,8 @@ migration_variables = {
 key_vault_subscription        = "74dacd4f-a248-45bb-a2f0-af700dc4cf68"
 hub_app_gw_private_ip_address = ["10.11.8.212"]
 apim_appgw_backend_pool_fqdns = ["firewall-prod-int-palo-sdsapimgmtstg.uksouth.cloudapp.azure.com"]
+apim_appgw_min_capacity       = 1
+apim_appgw_max_capacity       = 2
 
 frontends = [
 


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DTSPO-18453


### Change description ###

- Set min/max instances for stg apim appgw to 1/2
- Free's IP in subnet to allow aat apim appgw deployment


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


### environments/stg/stg.tfvars
- Added `apim_appgw_min_capacity` and `apim_appgw_max_capacity` with values 1 and 2.