### PR TITLE
Add additional routes to apim route table

### DIFF
--- a/components/apim/main.tf
+++ b/components/apim/main.tf
@@ -7,13 +7,14 @@ module "ctags" {
 }
 
 module "api-mgmt" {
-  source                         = "git::https://github.com/hmcts/cnp-module-api-mgmt-private.git?ref=main"
+  source                         = "git::https://github.com/hmcts/cnp-module-api-mgmt-private.git?ref=apim-private-additional-routes"
   location                       = var.location
   sku_name                       = var.apim_sku_name
   virtual_network_resource_group = var.vnet_rg
   virtual_network_name           = var.vnet_name
   environment                    = var.env
   virtual_network_type           = "Internal"
+  apim_additional_routes         = var.apim_additional_routes
   department                     = var.department
   common_tags                    = module.ctags.common_tags
   route_next_hop_in_ip_address   = local.hub[var.hub].ukSouth.next_hop_ip

--- a/components/apim/main.tf
+++ b/components/apim/main.tf
@@ -14,7 +14,7 @@ module "api-mgmt" {
   virtual_network_name           = var.vnet_name
   environment                    = var.env
   virtual_network_type           = "Internal"
-  apim_additional_routes         = var.apim_additional_routes
+  additional_routes_apim         = var.additional_routes_apim
   department                     = var.department
   common_tags                    = module.ctags.common_tags
   route_next_hop_in_ip_address   = local.hub[var.hub].ukSouth.next_hop_ip

--- a/components/apim/main.tf
+++ b/components/apim/main.tf
@@ -7,7 +7,7 @@ module "ctags" {
 }
 
 module "api-mgmt" {
-  source                         = "git::https://github.com/hmcts/cnp-module-api-mgmt-private.git?ref=apim-private-additional-routes"
+  source                         = "git::https://github.com/hmcts/cnp-module-api-mgmt-private.git?ref=main"
   location                       = var.location
   sku_name                       = var.apim_sku_name
   virtual_network_resource_group = var.vnet_rg

--- a/environments/stg/stg.tfvars
+++ b/environments/stg/stg.tfvars
@@ -25,7 +25,7 @@ hub_app_gw_private_ip_address = ["10.11.8.212"]
 apim_appgw_backend_pool_fqdns = ["firewall-prod-int-palo-sdsapimgmtstg.uksouth.cloudapp.azure.com"]
 apim_appgw_min_capacity       = 1
 apim_appgw_max_capacity       = 2
-apim_additional_routes = [
+additional_routes_apim = [
   {
     name                   = "ss-dev-vnet"
     address_prefix         = "10.145.0.0/18"

--- a/environments/stg/stg.tfvars
+++ b/environments/stg/stg.tfvars
@@ -25,6 +25,20 @@ hub_app_gw_private_ip_address = ["10.11.8.212"]
 apim_appgw_backend_pool_fqdns = ["firewall-prod-int-palo-sdsapimgmtstg.uksouth.cloudapp.azure.com"]
 apim_appgw_min_capacity       = 1
 apim_appgw_max_capacity       = 2
+apim_additional_routes = [
+  {
+    name                   = "ss-dev-vnet"
+    address_prefix         = "10.145.0.0/18"
+    next_hop_type          = "VirtualAppliance"
+    next_hop_in_ip_address = "10.11.72.36"
+  },
+  {
+    name                   = "ss-dev-vnet-egress-snat"
+    address_prefix         = "10.25.33.0/27"
+    next_hop_type          = "VirtualAppliance"
+    next_hop_in_ip_address = "10.11.72.37"
+  }
+]
 
 frontends = [
 

--- a/environments/variable.tf
+++ b/environments/variable.tf
@@ -46,7 +46,7 @@ variable "apim_appgw_exclusions" {
 variable "apim_appgw_min_capacity" {
   default = 2
 }
-variable "apim_additional_routes" {
+variable "additional_routes_apim" {
   description = "A list of additional route configurations"
   type = list(object({
     name                   = string

--- a/environments/variable.tf
+++ b/environments/variable.tf
@@ -47,7 +47,7 @@ variable "apim_appgw_min_capacity" {
   default = 2
 }
 variable "additional_routes_apim" {
-  description = "A list of additional route configurations"
+  description = "A list of additional routes configurations"
   type = list(object({
     name                   = string
     address_prefix         = string

--- a/environments/variable.tf
+++ b/environments/variable.tf
@@ -46,7 +46,16 @@ variable "apim_appgw_exclusions" {
 variable "apim_appgw_min_capacity" {
   default = 2
 }
-
+variable "apim_additional_routes" {
+  description = "A list of additional route configurations"
+  type = list(object({
+    name                   = string
+    address_prefix         = string
+    next_hop_type          = string
+    next_hop_in_ip_address = string
+  }))
+  default = []
+}
 variable "apim_appgw_max_capacity" {
   default = 10
 }


### PR DESCRIPTION
Allows for some snat ip ranges between ss-dev and ss-stg and uses new module changes to add these routes https://github.com/hmcts/cnp-module-api-mgmt-private/pull/55





## 🤖AEP PR SUMMARY🤖


### components/apim/main.tf
- Added a new input variable \"additional_routes_apim\" and assigned the value from the input variable `var.additional_routes_apim`.

### environments/stg/stg.tfvars
- Added additional routes configurations to the \"additional_routes_apim\" variable.

### environments/variable.tf
- Added a new input variable \"additional_routes_apim\" of type list(object) to define additional routes configurations.