### PR TITLE
PUB-2364 Add exclusion rule for pip-frontend QueryStringArgNames

### DIFF
--- a/environments/demo/demo.tfvars
+++ b/environments/demo/demo.tfvars
@@ -142,6 +142,11 @@ frontends = [
         selector       = "iss"
       },
       {
+        match_variable = "QueryStringArgNames"
+        operator       = "Equals"
+        selector       = "code"
+      },
+      {
         match_variable = "RequestBodyPostArgNames"
         operator       = "Equals"
         selector       = "error_description"

--- a/environments/ithc/ithc.tfvars
+++ b/environments/ithc/ithc.tfvars
@@ -107,6 +107,11 @@ frontends = [
         selector       = "iss"
       },
       {
+        match_variable = "QueryStringArgNames"
+        operator       = "Equals"
+        selector       = "code"
+      },
+      {
         match_variable = "RequestBodyPostArgNames"
         operator       = "Equals"
         selector       = "subscriptions"

--- a/environments/stg/stg.tfvars
+++ b/environments/stg/stg.tfvars
@@ -133,6 +133,11 @@ frontends = [
         selector       = "iss"
       },
       {
+        match_variable = "QueryStringArgNames"
+        operator       = "Equals"
+        selector       = "code"
+      },
+      {
         match_variable = "RequestBodyPostArgNames"
         operator       = "Equals"
         selector       = "subscriptions"

--- a/environments/test/test.tfvars
+++ b/environments/test/test.tfvars
@@ -129,6 +129,11 @@ frontends = [
         selector       = "iss"
       },
       {
+        match_variable = "QueryStringArgNames"
+        operator       = "Equals"
+        selector       = "code"
+      },
+      {
         match_variable = "RequestBodyPostArgNames"
         operator       = "Equals"
         selector       = "subscriptions"


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/PUB-2364

### Change description

Add exclusion rule for pip-frontend non-prod QueryStringArgNames to avoid requests getting block after SSO sign-in

### Testing done

Have checked the firewall logs and saw that the requests are getting blocked because of the query param value contains too many special characters. It is a genuine false positive.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


### environments/demo/demo.tfvars
- Added new configuration for frontends with `match_variable`, `operator`, and `selector` for \"code\".

### environments/ithc/ithc.tfvars
- Added new configuration for frontends with `match_variable`, `operator`, and `selector` for \"code\".

### environments/stg/stg.tfvars
- Added new configuration for frontends with `match_variable`, `operator`, and `selector` for \"code\".

### environments/test/test.tfvars
- Added new configuration for frontends with `match_variable`, `operator`, and `selector` for \"code\".