### PR TITLE
Update PRE test env rules to match prod

### DIFF
--- a/environments/test/test.tfvars
+++ b/environments/test/test.tfvars
@@ -432,15 +432,14 @@ frontends = [
         "942450",
         "942430",
       ],
-      RCE = [
-        "932100",
-        "932110",
-        "932115",
-      ],
-    }
-    health_protocol     = "Https"
-    forwarding_protocol = "HttpsOnly"
-    cache_enabled       = "false"
+    },
+    global_exclusions = [
+      {
+        match_variable = "QueryStringArgNames"
+        operator       = "Equals"
+        selector       = "code"
+      }
+    ],
 
     custom_rules = [
       {


### PR DESCRIPTION


## 🤖AEP PR SUMMARY🤖


- The file `environments/test/test.tfvars` has been modified to add global exclusions for a match_variable \"QueryStringArgNames\" with operator \"Equals\" and selector \"code\" within custom rules. The RCE values have been removed and \"health_protocol\" has been set to \"Https\", \"forwarding_protocol\" to \"HttpsOnly\", and \"cache_enabled\" to \"false\".