### PR TITLE
Do_Not_Merge - PUB-2679 - Updated ruleset

### DIFF
--- a/components/frontdoor/main.tf
+++ b/components/frontdoor/main.tf
@@ -29,7 +29,7 @@ moved {
   to   = module.premium_front_door
 }
 module "premium_front_door" {
-  source = "git::https://github.com/hmcts/terraform-module-frontdoor.git?ref=master"
+  source = "git::https://github.com/hmcts/terraform-module-frontdoor.git?ref=PUB-2679-Ruleset"
 
   common_tags                = module.ctags.common_tags
   env                        = var.env

--- a/environments/sbox/sbox.tfvars
+++ b/environments/sbox/sbox.tfvars
@@ -232,6 +232,9 @@ frontends = [
     backend_domain = ["firewall-sbox-int-palo-sdssbox.uksouth.cloudapp.azure.com"]
     shutter_app    = false
 
+    ruleset_type   = "Microsoft_DefaultRuleSet"
+    ruleset_value  = "2.1"
+
     disabled_rules = {}
 
     global_exclusions = [

--- a/environments/sbox/sbox.tfvars
+++ b/environments/sbox/sbox.tfvars
@@ -232,8 +232,8 @@ frontends = [
     backend_domain = ["firewall-sbox-int-palo-sdssbox.uksouth.cloudapp.azure.com"]
     shutter_app    = false
 
-    ruleset_type   = "Microsoft_DefaultRuleSet"
-    ruleset_value  = "2.1"
+    ruleset_type  = "Microsoft_DefaultRuleSet"
+    ruleset_value = "2.1"
 
     disabled_rules = {}
 


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/PUB-2679

### Change description

Testing the update of the firewall ruleset to version 2.1

### Testing done



## 🤖AEP PR SUMMARY🤖


### components/frontdoor/main.tf
- Changed source for module \"premium_front_door\" to \"git::https://github.com/hmcts/terraform-module-frontdoor.git?ref=PUB-2679-Ruleset\" 🔄
  
### environments/sbox/sbox.tfvars
- Added \"ruleset_type\" with value \"Microsoft_DefaultRuleSet\" and \"ruleset_value\" with value \"2.1\" 🔄