### PR TITLE
PUB-2727 Update WAF ruleset to 2.1 for demo and staging env

### DIFF
--- a/environments/demo/demo.tfvars
+++ b/environments/demo/demo.tfvars
@@ -92,7 +92,15 @@ frontends = [
     backend_domain   = ["firewall-nonprodi-palo-sdsdemoappgateway.uksouth.cloudapp.azure.com"]
     certificate_name = "wildcard-demo-platform-hmcts-net"
 
-    disabled_rules = {}
+    ruleset_type  = "Microsoft_DefaultRuleSet"
+    ruleset_value = "2.1"
+
+    disabled_rules = {
+      General = [
+        "200002",
+        "200003"
+      ]
+    }
 
     global_exclusions = [
       ## Open ID response parameters
@@ -125,16 +133,6 @@ frontends = [
         match_variable = "RequestCookieNames"
         operator       = "Equals"
         selector       = "court-and-tribunal-hearings-cookie-preferences"
-      },
-      {
-        match_variable = "RequestCookieNames"
-        operator       = "Equals"
-        selector       = "createAdminAccount"
-      },
-      {
-        match_variable = "RequestCookieNames"
-        operator       = "Equals"
-        selector       = "session.sig"
       },
       {
         match_variable = "QueryStringArgNames"

--- a/environments/demo/demo.tfvars
+++ b/environments/demo/demo.tfvars
@@ -95,10 +95,14 @@ frontends = [
     ruleset_type  = "Microsoft_DefaultRuleSet"
     ruleset_value = "2.1"
 
+    disabled_rules_action = "AnomalyScoring"
     disabled_rules = {
       General = [
         "200002",
         "200003"
+      ],
+      PROTOCOL-ENFORCEMENT = [
+        "920120"
       ]
     }
 

--- a/environments/ithc/ithc.tfvars
+++ b/environments/ithc/ithc.tfvars
@@ -52,6 +52,9 @@ frontends = [
     dns_zone_name  = "ithc.platform.hmcts.net"
     backend_domain = ["firewall-nonprodi-palo-sdsithc.uksouth.cloudapp.azure.com"]
 
+    ruleset_type  = "Microsoft_DefaultRuleSet"
+    ruleset_value = "2.1"
+
     disabled_rules = {}
 
     global_exclusions = [

--- a/environments/stg/stg.tfvars
+++ b/environments/stg/stg.tfvars
@@ -81,10 +81,14 @@ frontends = [
     ruleset_type  = "Microsoft_DefaultRuleSet"
     ruleset_value = "2.1"
 
+    disabled_rules_action = "AnomalyScoring"
     disabled_rules = {
       General = [
         "200002",
         "200003"
+      ],
+      PROTOCOL-ENFORCEMENT = [
+        "920120"
       ]
     }
 

--- a/environments/stg/stg.tfvars
+++ b/environments/stg/stg.tfvars
@@ -78,7 +78,15 @@ frontends = [
     dns_zone_name  = "staging.platform.hmcts.net"
     backend_domain = ["firewall-prod-int-palo-sdsstg.uksouth.cloudapp.azure.com"]
 
-    disabled_rules = {}
+    ruleset_type  = "Microsoft_DefaultRuleSet"
+    ruleset_value = "2.1"
+
+    disabled_rules = {
+      General = [
+        "200002",
+        "200003"
+      ]
+    }
 
     global_exclusions = [
       ## Open ID response parameters
@@ -111,16 +119,6 @@ frontends = [
         match_variable = "RequestCookieNames"
         operator       = "Equals"
         selector       = "court-and-tribunal-hearings-cookie-preferences"
-      },
-      {
-        match_variable = "RequestCookieNames"
-        operator       = "Equals"
-        selector       = "createAdminAccount"
-      },
-      {
-        match_variable = "RequestCookieNames"
-        operator       = "Equals"
-        selector       = "session.sig"
       },
       {
         match_variable = "RequestBodyPostArgNames"


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/PUB-2727

### Change description

Update WAF ruleset to 2.1 in demo env

### Testing done

Tested in ITHC env and false positive blocking has reduced in version 2.1

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change






## 🤖AEP PR SUMMARY🤖


- `environments/demo/demo.tfvars`:
  - Added `ruleset_type` and `ruleset_value` properties.
  - Updated `disabled_rules_action` and `disabled_rules` properties.

- `environments/stg/stg.tfvars`:
  - Added `ruleset_type` and `ruleset_value` properties.
  - Updated `disabled_rules_action` and `disabled_rules` properties.