### PR TITLE
Revert "adding test static app"

### DIFF
--- a/environments/sbox/sbox.tfvars
+++ b/environments/sbox/sbox.tfvars
@@ -308,11 +308,3 @@ apim_appgw_exclusions = [
   }
 ]
 
-additional_shutter_apps = [
-  {
-    name          = "test-shutter-app-new"
-    shutter_app   = true
-    dns_zone_name = "sandbox.platform.hmcts.net"
-    custom_domain = "test2.shutter.sandbox.platform.hmcts.net"
-  }
-]


### PR DESCRIPTION
Reverts hmcts/sds-azure-platform#889

## 🤖AEP PR SUMMARY🤖


### environments/sbox/sbox.tfvars
- Removed the `additional_shutter_apps` block containing a `test-shutter-app-new` configuration.