### PR TITLE
removing frontdoor domains decision tribunals

### DIFF
--- a/environments/prod/prod.tfvars
+++ b/environments/prod/prod.tfvars
@@ -202,47 +202,47 @@ frontends = [
       }
     ]
   },
-  {
-    name              = "trib-admin-appeals"
-    mode              = "Prevention"
-    custom_domain     = "administrativeappeals.decisions.tribunals.gov.uk"
-    dns_zone_name     = "decisions.tribunals.gov.uk"
-    backend_domain    = ["dts-tribs-prod-1612499966.eu-west-1.elb.amazonaws.com"]
-    shutter_app       = false
-    hosted_externally = true
-    cache_enabled     = false
+  # {
+  #   name              = "trib-admin-appeals"
+  #   mode              = "Prevention"
+  #   custom_domain     = "administrativeappeals.decisions.tribunals.gov.uk"
+  #   dns_zone_name     = "decisions.tribunals.gov.uk"
+  #   backend_domain    = ["dts-tribs-prod-1612499966.eu-west-1.elb.amazonaws.com"]
+  #   shutter_app       = false
+  #   hosted_externally = true
+  #   cache_enabled     = false
 
-    global_exclusions = [
-      {
-        match_variable = "RequestBodyPostArgNames"
-        operator       = "Equals"
-        selector       = "__VIEWSTATE"
-      },
-      {
-        match_variable = "RequestBodyPostArgNames"
-        operator       = "Equals"
-        selector       = "btnSearch"
-      }
-    ]
-    custom_rules = [
-      {
-        name     = "AllowAllAdmin",
-        type     = "MatchRule"
-        priority = 1
-        action   = "Allow"
+  #   global_exclusions = [
+  #     {
+  #       match_variable = "RequestBodyPostArgNames"
+  #       operator       = "Equals"
+  #       selector       = "__VIEWSTATE"
+  #     },
+  #     {
+  #       match_variable = "RequestBodyPostArgNames"
+  #       operator       = "Equals"
+  #       selector       = "btnSearch"
+  #     }
+  #   ]
+  #   custom_rules = [
+  #     {
+  #       name     = "AllowAllAdmin",
+  #       type     = "MatchRule"
+  #       priority = 1
+  #       action   = "Allow"
 
-        match_conditions = [
-          {
-            match_variable     = "RequestUri"
-            operator           = "Contains"
-            negation_condition = false
-            match_values = [
-            "/Admin", "/Secure"]
-          }
-        ]
-      }
-    ]
-  },
+  #       match_conditions = [
+  #         {
+  #           match_variable     = "RequestUri"
+  #           operator           = "Contains"
+  #           negation_condition = false
+  #           match_values = [
+  #           "/Admin", "/Secure"]
+  #         }
+  #       ]
+  #     }
+  #   ]
+  # },
   {
     name              = "trib-care-standards"
     mode              = "Prevention"


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/DTSPO-24370

### Change description

We've had a request for the Front Door domains related to all *.decisions.tribunals.gov.uk to be removed. They are no longer required as the domains are hosted in AWS Cloud Platform Route53.

- administrativeappeals.decisions.tribunals.gov.uk
- carestandards.decisions.tribunals.gov.uk
- cicap.decisions.tribunals.gov.uk
- employmentappeals.decisions.tribunals.gov.uk
- financeandtax.decisions.tribunals.gov.uk
- immigrationservices.decisions.tribunals.gov.uk
- informationrights.decisions.tribunals.gov.uk
- landregistrationdivision.decisions.tribunals.gov.uk
- landschamber.decisions.tribunals.gov.uk
- transportappeals.decisions.tribunals.gov.uk
- waf.tribunalsdecisions.service.gov.uk

