### PR TITLE
Bump 1.10.4 to 1.11.0 on backendapp-gateway and app-gateway component

### DIFF
--- a/components/apim/init.tf
+++ b/components/apim/init.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "1.10.4"
+  required_version = "1.11.0"
 
   backend "azurerm" {
     subscription_id = "04d27a32-7a07-48b3-95b8-3c8691e1a263"

--- a/components/appgateway/init.tf
+++ b/components/appgateway/init.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "1.10.4"
+  required_version = "1.10.5"
 
   backend "azurerm" {
     subscription_id = "04d27a32-7a07-48b3-95b8-3c8691e1a263"

--- a/components/appgateway/init.tf
+++ b/components/appgateway/init.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "1.10.5"
+  required_version = "1.11.0"
 
   backend "azurerm" {
     subscription_id = "04d27a32-7a07-48b3-95b8-3c8691e1a263"

--- a/components/backendappgateway/init.tf
+++ b/components/backendappgateway/init.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "1.10.4"
+  required_version = "1.10.5"
 
   backend "azurerm" {
     subscription_id = "04d27a32-7a07-48b3-95b8-3c8691e1a263"

--- a/components/backendappgateway/init.tf
+++ b/components/backendappgateway/init.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "1.10.5"
+  required_version = "1.11.0"
 
   backend "azurerm" {
     subscription_id = "04d27a32-7a07-48b3-95b8-3c8691e1a263"

--- a/components/shutter_static_webapp/init.tf
+++ b/components/shutter_static_webapp/init.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "1.10.4"
+  required_version = "1.11.0"
 
   backend "azurerm" {}
   required_providers {

--- a/components/trafficmanager/init.tf
+++ b/components/trafficmanager/init.tf
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.100.0"
+      version = "4.0.0"
     }
   }
 }

--- a/components/trafficmanager/init.tf
+++ b/components/trafficmanager/init.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "1.10.4"
+  required_version = "1.11.0"
 
   backend "azurerm" {
     subscription_id = "04d27a32-7a07-48b3-95b8-3c8691e1a263"


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/DTSPO-24542

### Change description
Looks like backendapp-gateway and app-gateway components are now running TF v1.11.0
Bump the required_version to match this and fix the current failures

### Testing done
I checked the change log and 1.11.0 doesn't have any breaking changes

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change








## 🤖AEP PR SUMMARY🤖


- **components/apim/init.tf**
  - Updated the required Terraform version from \"1.10.4\" to \"1.11.0\".
  
- **components/appgateway/init.tf**
  - Updated the required Terraform version from \"1.10.4\" to \"1.11.0\".

- **components/backendappgateway/init.tf**
  - Updated the required Terraform version from \"1.10.4\" to \"1.11.0\".

- **components/shutter_static_webapp/init.tf**
  - Updated the required Terraform version from \"1.10.4\" to \"1.11.0\".

- **components/trafficmanager/init.tf**
  - Updated the required Terraform version from \"1.10.4\" to \"1.11.0\".
  - Updated the Azurerm provider version from \"3.100.0\" to \"4.0.0\".