### PR TITLE
Add-custom-timeout-darts-gw

### DIFF
--- a/components/apim/init.tf
+++ b/components/apim/init.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "1.11.0"
+  required_version = "1.11.1"
 
   backend "azurerm" {
     subscription_id = "04d27a32-7a07-48b3-95b8-3c8691e1a263"

--- a/components/apim_appgw/init.tf
+++ b/components/apim_appgw/init.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.4.6"
+  required_version = ">= 1.11.1"
 
   backend "azurerm" {
   }

--- a/components/appgateway/init.tf
+++ b/components/appgateway/init.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "1.11.0"
+  required_version = "1.11.1"
 
   backend "azurerm" {
     subscription_id = "04d27a32-7a07-48b3-95b8-3c8691e1a263"

--- a/components/backendappgateway/init.tf
+++ b/components/backendappgateway/init.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "1.11.0"
+  required_version = "1.11.1"
 
   backend "azurerm" {
     subscription_id = "04d27a32-7a07-48b3-95b8-3c8691e1a263"

--- a/components/frontdoor/init.tf
+++ b/components/frontdoor/init.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.6.0"
+  required_version = ">= 1.11.1"
 
   backend "azurerm" {
     subscription_id = "04d27a32-7a07-48b3-95b8-3c8691e1a263"

--- a/components/shutter_static_webapp/init.tf
+++ b/components/shutter_static_webapp/init.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "1.11.0"
+  required_version = "1.11.1"
 
   backend "azurerm" {}
   required_providers {

--- a/components/trafficmanager/init.tf
+++ b/components/trafficmanager/init.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "1.11.0"
+  required_version = "1.11.1"
 
   backend "azurerm" {
     subscription_id = "04d27a32-7a07-48b3-95b8-3c8691e1a263"

--- a/environments/stg/backend_lb_config.yaml
+++ b/environments/stg/backend_lb_config.yaml
@@ -54,9 +54,11 @@ gateways:
       - product: darts
         component: api
         ssl_enabled: true
+        request_timeout: 45
       - product: darts
         component: gateway
         ssl_enabled: false
+        request_timeout: 45
       - product: darts
         component: stub-services
         ssl_enabled: false


### PR DESCRIPTION
### Jira link

See [DTSPO-24171](https://tools.hmcts.net/jira/browse/DTSPO-24171)

### Change description

The database can be slow to return replies and testing has shown 45 seconds is enough to prevent time out errors by the App Gateway.

### Testing done

Have tested the setting by manually changing the value in the Azure portal.  No testing required for this code, as it only requires the request_timeout: 45 value setting in the configuration file.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [X] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change








## 🤖AEP PR SUMMARY🤖


- components/apim/init.tf
  - Upgraded the required Terraform version from 1.11.0 to 1.11.1.

- components/apim_appgw/init.tf
  - Upgraded the required Terraform version from \">= 1.4.6\" to \">= 1.11.1\".

- components/appgateway/init.tf
  - Upgraded the required Terraform version from 1.11.0 to 1.11.1.

- components/backendappgateway/init.tf
  - Upgraded the required Terraform version from 1.11.0 to 1.11.1.

- components/frontdoor/init.tf
  - Upgraded the required Terraform version from \">= 1.6.0\" to \">= 1.11.1\".

- components/shutter_static_webapp/init.tf
  - Upgraded the required Terraform version from 1.11.0 to 1.11.1.

- components/trafficmanager/init.tf
  - Upgraded the required Terraform version from 1.11.0 to 1.11.1.

- environments/stg/backend_lb_config.yaml
  - Updated the request_timeout for various components within the backend_lb_config.yaml file.