### PR TITLE
remove prod domain waf tribunals decisions 

### DIFF
--- a/environments/prod/prod.tfvars
+++ b/environments/prod/prod.tfvars
@@ -67,14 +67,6 @@ frontends = [
     hosted_externally = true
   },
   {
-    name           = "dts-legacy-apps---utiac"
-    mode           = "Detection" #detection config set and PR raised 20 Dec 2021
-    custom_domain  = "waf.tribunalsdecisions.service.gov.uk"
-    dns_zone_name  = "tribunalsdecisions.service.gov.uk"
-    backend_domain = ["dualstack.dsd-apps-lb-01-1379550980.eu-west-1.elb.amazonaws.com"]
-    shutter_app    = false
-  },
-  {
     name             = "jd-bureau"
     custom_domain    = "juror-bureau.justice.gov.uk"
     dns_zone_name    = "juror-bureau.justice.gov.uk"


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/DTSPO-24370https://tools.hmcts.net/jira/browse/DTSPO-24370

### Change description
This PR is to remove "waf.tribunalsdecisions.service.gov.uk" and Mark Butler advised they previously used AFD and the WAF to act as a frontend for the tribunals decisions and utiac services hosted in AWS, but they have migrated all of these services to a new AWS platform and no longer require the Azure resources

### Testing done

Removed other domains on this merged PR - https://github.com/hmcts/sds-azure-platform/pull/901 

## 🤖AEP PR SUMMARY🤖


diff
environments/prod/prod.tfvars
- Removed a block for \"dts-legacy-apps---utiac\" from the frontends list, including its name, mode, custom_domain, dns_zone_name, backend_domain, and shutter_app attributes, as they are no longer necessary.
- Adjusted the custom_domain for \"jd-bureau\" to \"juror-bureau.justice.gov.uk\".
```