### PR TITLE
PUB-2778 Update WAF to ruleset 2.1 for PIP B2C on demo env

### DIFF
--- a/environments/demo/demo.tfvars
+++ b/environments/demo/demo.tfvars
@@ -176,10 +176,10 @@ frontends = [
     cache_enabled       = false
     shutter_app         = false
 
-    ruleset_type        = "Microsoft_DefaultRuleSet"
-    ruleset_value       = "2.1"
+    ruleset_type  = "Microsoft_DefaultRuleSet"
+    ruleset_value = "2.1"
 
-    disabled_rules      = {}
+    disabled_rules = {}
     global_exclusions = [
       {
         match_variable = "QueryStringArgNames"
@@ -228,10 +228,10 @@ frontends = [
     cache_enabled       = false
     shutter_app         = false
 
-    ruleset_type        = "Microsoft_DefaultRuleSet"
-    ruleset_value       = "2.1"
+    ruleset_type  = "Microsoft_DefaultRuleSet"
+    ruleset_value = "2.1"
 
-    disabled_rules      = {}
+    disabled_rules = {}
     global_exclusions = [
       {
         match_variable = "QueryStringArgNames"

--- a/environments/demo/demo.tfvars
+++ b/environments/demo/demo.tfvars
@@ -175,6 +175,10 @@ frontends = [
     forwarding_protocol = "HttpsOnly"
     cache_enabled       = false
     shutter_app         = false
+
+    ruleset_type        = "Microsoft_DefaultRuleSet"
+    ruleset_value       = "2.1"
+
     disabled_rules      = {}
     global_exclusions = [
       {
@@ -183,14 +187,9 @@ frontends = [
         selector       = "redirect_uri"
       },
       {
-        match_variable = "QueryStringArgNames"
+        match_variable = "RequestBodyPostArgNames"
         operator       = "Equals"
-        selector       = "desc"
-      },
-      {
-        match_variable = "RequestCookieNames"
-        operator       = "StartsWith"
-        selector       = "x-ms-cpim-"
+        selector       = "redirect_uri"
       },
       {
         match_variable = "QueryStringArgNames"
@@ -198,54 +197,24 @@ frontends = [
         selector       = "diags"
       },
       {
-        match_variable = "RequestBodyPostArgNames"
-        operator       = "Equals"
-        selector       = "redirect_uri"
-      },
-      {
-        match_variable = "RequestBodyPostArgNames"
-        operator       = "Equals"
-        selector       = "error_description"
-      },
-      {
-        match_variable = "RequestBodyPostArgNames"
-        operator       = "Equals"
-        selector       = "code"
-      },
-      {
-        match_variable = "RequestBodyPostArgNames"
-        operator       = "Equals"
-        selector       = "claim_value"
-      },
-      {
-        match_variable = "RequestBodyPostArgNames"
-        operator       = "Equals"
-        selector       = "ReadOnlyEmail"
-      },
-      {
         match_variable = "QueryStringArgNames"
-        operator       = "Equals"
-        selector       = "nonce"
-      },
-      {
-        match_variable = "QueryStringArgNames"
-        operator       = "Equals"
-        selector       = "state"
-      },
-      {
-        match_variable = "QueryStringArgNames"
-        operator       = "Equals"
-        selector       = "post_logout_redirect_uri"
-      },
-      {
-        match_variable = "RequestBodyPostArgNames"
         operator       = "Equals"
         selector       = "post_logout_redirect_uri"
       },
       {
         match_variable = "RequestCookieNames"
-        operator       = "Equals"
-        selector       = "dtSa"
+        operator       = "StartsWith"
+        selector       = "x-ms-cpim-"
+      },
+      {
+        match_variable = "RequestBodyJsonArgNames"
+        operator       = "Contains"
+        selector       = "entries.name"
+      },
+      {
+        match_variable = "RequestBodyJsonArgNames"
+        operator       = "Contains"
+        selector       = "entries.scripts"
       }
     ]
   },
@@ -258,6 +227,10 @@ frontends = [
     forwarding_protocol = "HttpsOnly"
     cache_enabled       = false
     shutter_app         = false
+
+    ruleset_type        = "Microsoft_DefaultRuleSet"
+    ruleset_value       = "2.1"
+
     disabled_rules      = {}
     global_exclusions = [
       {
@@ -266,14 +239,9 @@ frontends = [
         selector       = "redirect_uri"
       },
       {
-        match_variable = "QueryStringArgNames"
+        match_variable = "RequestBodyPostArgNames"
         operator       = "Equals"
-        selector       = "desc"
-      },
-      {
-        match_variable = "RequestCookieNames"
-        operator       = "StartsWith"
-        selector       = "x-ms-cpim-"
+        selector       = "redirect_uri"
       },
       {
         match_variable = "QueryStringArgNames"
@@ -281,54 +249,24 @@ frontends = [
         selector       = "diags"
       },
       {
-        match_variable = "RequestBodyPostArgNames"
-        operator       = "Equals"
-        selector       = "redirect_uri"
-      },
-      {
-        match_variable = "RequestBodyPostArgNames"
-        operator       = "Equals"
-        selector       = "error_description"
-      },
-      {
-        match_variable = "RequestBodyPostArgNames"
-        operator       = "Equals"
-        selector       = "code"
-      },
-      {
-        match_variable = "RequestBodyPostArgNames"
-        operator       = "Equals"
-        selector       = "claim_value"
-      },
-      {
-        match_variable = "RequestBodyPostArgNames"
-        operator       = "Equals"
-        selector       = "ReadOnlyEmail"
-      },
-      {
         match_variable = "QueryStringArgNames"
-        operator       = "Equals"
-        selector       = "nonce"
-      },
-      {
-        match_variable = "QueryStringArgNames"
-        operator       = "Equals"
-        selector       = "state"
-      },
-      {
-        match_variable = "QueryStringArgNames"
-        operator       = "Equals"
-        selector       = "post_logout_redirect_uri"
-      },
-      {
-        match_variable = "RequestBodyPostArgNames"
         operator       = "Equals"
         selector       = "post_logout_redirect_uri"
       },
       {
         match_variable = "RequestCookieNames"
-        operator       = "Equals"
-        selector       = "dtSa"
+        operator       = "StartsWith"
+        selector       = "x-ms-cpim-"
+      },
+      {
+        match_variable = "RequestBodyJsonArgNames"
+        operator       = "Contains"
+        selector       = "entries.name"
+      },
+      {
+        match_variable = "RequestBodyJsonArgNames"
+        operator       = "Contains"
+        selector       = "entries.scripts"
       }
     ]
   },


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/PUB-2778

### Change description

Update WAF to ruleset 2.1 PIP B2C on demo env

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change




## 🤖AEP PR SUMMARY🤖


- `environments/demo/demo.tfvars`
  - Updated `ruleset_type` and `ruleset_value` to \"Microsoft_DefaultRuleSet\" and \"2.1\" respectively.
  - Removed and reorganized several global exclusions for better clarity.
  - Made adjustments to `match_variable`, `operator`, and `selector` attributes within global exclusions.