### PR TITLE
Adding Courtfines FD config to Demo and ITHC

### DIFF
--- a/environments/demo/demo.tfvars
+++ b/environments/demo/demo.tfvars
@@ -508,6 +508,13 @@ frontends = [
     }
     global_exclusions = []
   },
+  {
+    name           = "hmcts-courtfines-demo"
+    custom_domain  = "courtfines-app.demo.platform.hmcts.net"
+    dns_zone_name  = "demo.platform.hmcts.net"
+    backend_domain = ["firewall-nonprodi-palo-sdsdemoappgateway.uksouth.cloudapp.azure.com"]
+    disabled_rules = {}
+  },
 ]
 
 apim_appgw_exclusions = [

--- a/environments/ithc/ithc.tfvars
+++ b/environments/ithc/ithc.tfvars
@@ -396,7 +396,14 @@ frontends = [
         selector       = "user_ids"
       },
     ]
-  }
+  },
+  {
+    name           = "hmcts-courtfines-ithc"
+    custom_domain  = "courtfines-app.ithc.apps.hmcts.net"
+    dns_zone_name  = "apps.hmcts.net"
+    backend_domain = ["firewall-nonprodi-palo-sdsithc.uksouth.cloudapp.azure.com"]
+    disabled_rules = {}
+  },
 ]
 
 apim_appgw_exclusions = [


### PR DESCRIPTION
Adding Courtfines FD config to Demo and ITHC





## 🤖AEP PR SUMMARY🤖


- `demo.tfvars`:
  - Added a new configuration for \"hmcts-courtfines-demo\" with custom domain, DNS zone name, backend domain, and disabled rules.

- `ithc.tfvars`:
  - Added a new configuration for \"hmcts-courtfines-ithc\" with custom domain, DNS zone name, backend domain, and disabled rules.