### PR TITLE
Updated Courtfines CNAME

### DIFF
--- a/environments/stg/stg.tfvars
+++ b/environments/stg/stg.tfvars
@@ -814,7 +814,7 @@ frontends = [
   },
   {
     name           = "hmcts-courtfines-staging"
-    custom_domain  = "courtfines-app-staging.staging.platform.hmcts.net"
+    custom_domain  = "courtfines-app.staging.platform.hmcts.net"
     dns_zone_name  = "staging.platform.hmcts.net"
     backend_domain = ["firewall-prod-int-palo-sdsstg.uksouth.cloudapp.azure.com"]
     disabled_rules = {}


### PR DESCRIPTION
Updated Courtfines CNAME

## 🤖AEP PR SUMMARY🤖


### environments/stg/stg.tfvars
- Changed the `custom_domain` from \"courtfines-app-staging.staging.platform.hmcts.net\" to \"courtfines-app.staging.platform.hmcts.net\" for the \"hmcts-courtfines-staging\" frontend.