### PR TITLE
Add opal-frontend configuration to test environment

### DIFF
--- a/environments/test/test.tfvars
+++ b/environments/test/test.tfvars
@@ -489,7 +489,7 @@ frontends = [
     }
     global_exclusions = []
   }
-  
+
 ]
 
 apim_appgw_exclusions = [


### PR DESCRIPTION
Added opal test env


## 🤖AEP PR SUMMARY🤖


- **test.tfvars**
  - Added a new frontend configuration for \"opal-frontend\" with custom domain, DNS zone name, backend domain, cache settings, and disabled rules.