### PR TITLE
Revert "temp enable app insights on sds test for dets-arm perf testing"

### DIFF
--- a/components/backendappgateway/main.tf
+++ b/components/backendappgateway/main.tf
@@ -36,7 +36,6 @@ module "backendappgateway" {
   ssl_policy                 = var.ssl_policy
   common_tags                = module.ctags.common_tags
 
-  send_access_logs_to_log_analytics  = var.send_access_logs_to_log_analytics
   diagnostics_storage_account_id     = data.azurerm_storage_account.diagnostics.id
   enable_multiple_availability_zones = true
 }

--- a/environments/test/test.tfvars
+++ b/environments/test/test.tfvars
@@ -14,8 +14,7 @@ ssl_policy = {
   policy_name          = "AppGwSslPolicy20220101S"
   min_protocol_version = "TLSv1_2"
 }
-ssl_certificate                   = "wildcard-test-platform-hmcts-net"
-send_access_logs_to_log_analytics = true
+ssl_certificate = "wildcard-test-platform-hmcts-net"
 
 key_vault_subscription        = "3eec5bde-7feb-4566-bfb6-805df6e10b90"
 hub_app_gw_private_ip_address = ["10.11.72.239"]

--- a/environments/variable.tf
+++ b/environments/variable.tf
@@ -23,7 +23,6 @@ variable "apim_sku_name" { default = "Developer" }
 variable "hub" { default = "sbox" }
 variable "ssl_policy" { default = null }
 variable "ssl_certificate" {}
-variable "send_access_logs_to_log_analytics" { default = false }
 
 variable "key_vault_subscription" {
   default = []


### PR DESCRIPTION
Reverts hmcts/sds-azure-platform#954

Reverting as enabling this was only temporary DTSPO-26574

## 🤖AEP PR SUMMARY🤖


ℹ️ main.tf
- Removed the `send_access_logs_to_log_analytics` variable from the `module \"backendappgateway\"` block.

⚙️ test.tfvars
- Updated the value of `ssl_certificate` from \"wildcard-test-platform-hmcts-net\" to \"wildcard-test-platform-hmcts-net\".
- Changed `send_access_logs_to_log_analytics` from true to removed.

📦 variable.tf
- Removed the `send_access_logs_to_log_analytics` variable definition.