### PR TITLE
ARCPOC-168 - Added AppReg FD initial config

### DIFF
--- a/environments/demo/backend_lb_config.yaml
+++ b/environments/demo/backend_lb_config.yaml
@@ -88,4 +88,8 @@ gateways:
       - product: pdda
         component: public-display-manager
         ssl_enabled: true
+    # Apps Reg
+      - product: appreg
+        component: api
+        ssl_enabled: true
         

--- a/environments/demo/demo.tfvars
+++ b/environments/demo/demo.tfvars
@@ -515,6 +515,13 @@ frontends = [
     backend_domain = ["firewall-nonprodi-palo-sdsdemoappgateway.uksouth.cloudapp.azure.com"]
     disabled_rules = {}
   },
+  {
+    name           = "AppReg"
+    custom_domain  = "appreg.demo.apps.hmcts.net"
+    dns_zone_name  = "apps.hmcts.net"
+    backend_domain = ["firewall-nonprodi-palo-sdsdemoappgateway.uksouth.cloudapp.azure.com"]
+    disabled_rules = {}
+  },
 ]
 
 apim_appgw_exclusions = [

--- a/environments/dev/backend_lb_config.yaml
+++ b/environments/dev/backend_lb_config.yaml
@@ -32,3 +32,7 @@ gateways:
       - product: pre
         component: api
         ssl_enabled: true
+      # Apps Reg
+      - product: appreg
+        component: api
+        ssl_enabled: true

--- a/environments/ithc/backend_lb_config.yaml
+++ b/environments/ithc/backend_lb_config.yaml
@@ -45,3 +45,7 @@ gateways:
       - product: pip
         component: account-management
         ssl_enabled: true
+      # Apps Reg
+      - product: appreg
+        component: api
+        ssl_enabled: true

--- a/environments/ithc/ithc.tfvars
+++ b/environments/ithc/ithc.tfvars
@@ -404,6 +404,13 @@ frontends = [
     backend_domain = ["firewall-nonprodi-palo-sdsithc.uksouth.cloudapp.azure.com"]
     disabled_rules = {}
   },
+  {
+    name           = "AppReg"
+    custom_domain  = "appreg.ithc.apps.hmcts.net"
+    dns_zone_name  = "apps.hmcts.net"
+    backend_domain = ["firewall-nonprodi-palo-sdsithc.uksouth.cloudapp.azure.com"]
+    disabled_rules = {}
+  },
 ]
 
 apim_appgw_exclusions = [

--- a/environments/stg/backend_lb_config.yaml
+++ b/environments/stg/backend_lb_config.yaml
@@ -90,3 +90,7 @@ gateways:
       - product: pdda
         component: public-display-manager
         ssl_enabled: true
+    # Apps Reg
+      - product: appreg
+        component: api
+        ssl_enabled: true

--- a/environments/stg/stg.tfvars
+++ b/environments/stg/stg.tfvars
@@ -818,6 +818,13 @@ frontends = [
     backend_domain = ["firewall-prod-int-palo-sdsstg.uksouth.cloudapp.azure.com"]
     disabled_rules = {}
   },
+  {
+    name           = "AppReg"
+    custom_domain  = "appreg.staging.apps.hmcts.net"
+    dns_zone_name  = "apps.hmcts.net"
+    backend_domain = ["firewall-prod-int-palo-sdsstg.uksouth.cloudapp.azure.com"]
+    disabled_rules = {}
+  },
 ]
 
 apim_appgw_exclusions = [


### PR DESCRIPTION
Added initial config for Appreg - FD and LB

## 🤖AEP PR SUMMARY🤖


- `environments/demo/backend_lb_config.yaml`:
  - Added SSL configuration for a new product \"appreg\" and component \"api\".

- `environments/demo/demo.tfvars`:
  - Added a new frontend configuration for \"AppReg\" with custom domain and backend domain.

- `environments/dev/backend_lb_config.yaml`:
  - Added SSL configuration for a new product \"appreg\" and component \"api\".

- `environments/ithc/backend_lb_config.yaml`:
  - Added SSL configuration for a new product \"appreg\" and component \"api\".

- `environments/ithc/ithc.tfvars`:
  - Added a new frontend configuration for \"AppReg\" with custom domain and backend domain.

- `environments/stg/backend_lb_config.yaml`:
  - Added SSL configuration for a new product \"appreg\" and component \"api\".

- `environments/stg/stg.tfvars`:
  - Added a new frontend configuration for \"AppReg\" with custom domain and backend domain.