### PR TITLE
Defined weight to match real world value from portal

### DIFF
--- a/environments/prod/prod.tfvars
+++ b/environments/prod/prod.tfvars
@@ -778,11 +778,13 @@ traffic_manager_profiles = {
     endpoints = {
       fw-uksouth-prod-int-palo-mailrelay0-pip = {
         target_resource_id = "/subscriptions/0978315c-75fe-4ada-9d11-1eb5e0e0b214/resourceGroups/hmcts-hub-prod-int/providers/Microsoft.Network/publicIPAddresses/fw-uksouth-prod-int-palo-mailrelay0-pip",
+        weight             = 50
       },
       fw-uksouth-prod-int-palo-mailrelay1-pip = {
         profile_name        = "ss-prod-mailrelay-tm",
         resource_group_name = "ss-prod-network-rg",
         target_resource_id  = "/subscriptions/0978315c-75fe-4ada-9d11-1eb5e0e0b214/resourceGroups/hmcts-hub-prod-int/providers/Microsoft.Network/publicIPAddresses/fw-uksouth-prod-int-palo-mailrelay1-pip",
+        weight              = 1
       }
     }
   }


### PR DESCRIPTION
### Jira link

See [DTSPO-27571](https://tools.hmcts.net/jira/browse/DTSPO-27571)

### Change description

Defined weight to match real world value from portal - pipeline error showing both endpoints cannot have same priority. Azure appears to be defaulting to priority routing as weighted routing not explicitly defined

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behaviour remains the same.
-->

### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [X] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [X] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change




## 🤖AEP PR SUMMARY🤖


### environments/prod/prod.tfvars
- Updated the weight for \"fw-uksouth-prod-int-palo-mailrelay0-pip\" endpoint to 50.
- Added a weight of 1 for \"fw-uksouth-prod-int-palo-mailrelay1-pip\" endpoint.
- These changes are related to the traffic manager profiles.