### PR TITLE
Set weight and priority values on fw-uksouth-prod-int-palo-mailrelay0-pip to match current state and fix issue with identical priority being used as other endpoint

### DIFF
--- a/environments/prod/prod.tfvars
+++ b/environments/prod/prod.tfvars
@@ -798,6 +798,8 @@ traffic_manager_profiles = {
     endpoints = {
       fw-uksouth-prod-int-palo-mailrelay0-pip = {
         target_resource_id = "/subscriptions/0978315c-75fe-4ada-9d11-1eb5e0e0b214/resourceGroups/hmcts-hub-prod-int/providers/Microsoft.Network/publicIPAddresses/fw-uksouth-prod-int-palo-mailrelay0-pip",
+        weight             = "50"
+        priority           = 2
       },
       fw-uksouth-prod-int-palo-mailrelay1-pip = {
         profile_name        = "ss-prod-mailrelay-tm",


### PR DESCRIPTION
### Jira link
Fixing daily checks

### Change description
Set weight and priority values on fw-uksouth-prod-int-palo-mailrelay0-pip to match current state and fix issue with identical priority being used as other endpoint
This is because with no values set, default value of priority of 1 was being used


### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behaviour remains the same.
-->

### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change




## 🤖AEP PR SUMMARY🤖


### environments/prod/prod.tfvars
- Added a new \"weight\" and \"priority\" parameter to the \"fw-uksouth-prod-int-palo-mailrelay0-pip\" endpoint in the \"traffic_manager_profiles\" section.