### PR TITLE
Added Opal Logging service

### DIFF
--- a/environments/demo/backend_lb_config.yaml
+++ b/environments/demo/backend_lb_config.yaml
@@ -72,6 +72,9 @@ gateways:
         component: fines-service
         ssl_enabled: true
       - product: opal
+        component: logging-service
+        ssl_enabled: true
+      - product: opal
         component: legacy-db-stub
         ssl_enabled: true
       - product: opal

--- a/environments/ithc/backend_lb_config.yaml
+++ b/environments/ithc/backend_lb_config.yaml
@@ -54,6 +54,9 @@ gateways:
         component: fines-service
         ssl_enabled: true
       - product: opal
+        component: logging-service
+        ssl_enabled: true
+      - product: opal
         component: legacy-db-stub
         ssl_enabled: true
       - product: opal

--- a/environments/stg/backend_lb_config.yaml
+++ b/environments/stg/backend_lb_config.yaml
@@ -69,6 +69,9 @@ gateways:
         component: fines-service
         ssl_enabled: true
       - product: opal
+        component: logging-service
+        ssl_enabled: true
+      - product: opal
         component: legacy-db-stub
         ssl_enabled: true
       - product: opal

--- a/environments/test/backend_lb_config.yaml
+++ b/environments/test/backend_lb_config.yaml
@@ -72,6 +72,9 @@ gateways:
         component: fines-service
         ssl_enabled: true
       - product: opal
+        component: logging-service
+        ssl_enabled: true
+      - product: opal
         component: legacy-db-stub
         ssl_enabled: true
       - product: opal


### PR DESCRIPTION
Added Opal Logging service

## Link to Terraform Plan ##

https://tfplan-viewer.hmcts.net/sds-azure-platform/1009

## 🤖AEP PR SUMMARY🤖


### environments/demo/backend_lb_config.yaml
- Added SSL configuration for the logging-service component of the opal product.

### environments/ithc/backend_lb_config.yaml
- Added SSL configuration for the logging-service component of the opal product.

### environments/stg/backend_lb_config.yaml
- Added SSL configuration for the logging-service component of the opal product.

### environments/test/backend_lb_config.yaml
- Added SSL configuration for the logging-service component of the opal product.