### PR TITLE
juror: add er-portal

### DIFF
--- a/environments/demo/demo.tfvars
+++ b/environments/demo/demo.tfvars
@@ -515,6 +515,55 @@ frontends = [
     ]
   },
   {
+    product        = "juror-er-portal"
+    name           = "juror-er-portal"
+    custom_domain  = "juror-er.demo.apps.hmcts.net"
+    dns_zone_name  = "apps.hmcts.net"
+    backend_domain = ["firewall-nonprodi-palo-sdsdemoappgateway.uksouth.cloudapp.azure.com"]
+    cache_enabled  = "false"
+    mode           = "Prevention"
+    custom_rules = [
+      {
+        name     = "IPMatchWhitelist"
+        priority = 1
+        type     = "MatchRule"
+        action   = "Block"
+        match_conditions = [
+          {
+            match_variable     = "RemoteAddr"
+            operator           = "IPMatch"
+            negation_condition = true
+            match_values = [
+              "20.26.11.71/32",
+              "20.26.11.108/32",
+              "20.49.214.199/32",
+              "20.49.214.228/32",
+              "20.58.23.145/32",
+              "51.149.249.0/27",
+              "51.149.249.32/27",
+              "51.149.250.0/23",
+              "128.77.75.64/26",
+              "194.33.192.0/24",
+              "194.33.196.0/24",
+              "194.33.200.0/21",
+              "194.33.216.0/23",
+              "194.33.218.0/24",
+              "194.33.248.0/24",
+              "194.33.249.0/24",
+              "195.59.75.0/24",
+              #Prod Hubs
+              "20.50.108.242/32",
+              "20.50.109.148/32",
+              #NonProd Hubs
+              "20.49.168.141/32",
+              "20.49.168.17/32",
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
     name           = "opal-frontend"
     custom_domain  = "opal-frontend.demo.platform.hmcts.net"
     dns_zone_name  = "demo.platform.hmcts.net"

--- a/environments/ithc/ithc.tfvars
+++ b/environments/ithc/ithc.tfvars
@@ -381,6 +381,55 @@ frontends = [
     ]
   },
   {
+    product        = "juror-er-portal"
+    name           = "juror-er-portal"
+    custom_domain  = "juror-er.ithc.apps.hmcts.net"
+    dns_zone_name  = "apps.hmcts.net"
+    backend_domain = ["firewall-nonprodi-palo-sdsithc.uksouth.cloudapp.azure.com"]
+    cache_enabled  = "false"
+    mode           = "Prevention"
+    custom_rules = [
+      {
+        name     = "IPMatchWhitelist"
+        priority = 1
+        type     = "MatchRule"
+        action   = "Block"
+        match_conditions = [
+          {
+            match_variable     = "RemoteAddr"
+            operator           = "IPMatch"
+            negation_condition = true
+            match_values = [
+              "20.26.11.71/32",
+              "20.26.11.108/32",
+              "20.49.214.199/32",
+              "20.49.214.228/32",
+              "20.58.23.145/32",
+              "51.149.249.0/27",
+              "51.149.249.32/27",
+              "51.149.250.0/23",
+              "128.77.75.64/26",
+              "194.33.192.0/24",
+              "194.33.196.0/24",
+              "194.33.200.0/21",
+              "194.33.216.0/23",
+              "194.33.218.0/24",
+              "194.33.248.0/24",
+              "194.33.249.0/24",
+              "195.59.75.0/24",
+              #Prod Hubs
+              "20.50.108.242/32",
+              "20.50.109.148/32",
+              #NonProd Hubs
+              "20.49.168.141/32",
+              "20.49.168.17/32",
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
     name           = "opal-frontend"
     custom_domain  = "opal-frontend.ithc.platform.hmcts.net"
     dns_zone_name  = "ithc.platform.hmcts.net"

--- a/environments/prod/prod.tfvars
+++ b/environments/prod/prod.tfvars
@@ -696,6 +696,55 @@ frontends = [
     ]
   },
   {
+    product        = "juror-er-portal"
+    name           = "juror-er-portal"
+    custom_domain  = "juror-er.prod.apps.hmcts.net"
+    dns_zone_name  = "apps.hmcts.net"
+    backend_domain = ["firewall-prod-int-palo-sdsprod.uksouth.cloudapp.azure.com"]
+    cache_enabled  = "false"
+    mode           = "Prevention"
+    custom_rules = [
+      {
+        name     = "IPMatchWhitelist"
+        priority = 1
+        type     = "MatchRule"
+        action   = "Block"
+        match_conditions = [
+          {
+            match_variable     = "RemoteAddr"
+            operator           = "IPMatch"
+            negation_condition = true
+            match_values = [
+              "20.26.11.71/32",
+              "20.26.11.108/32",
+              "20.49.214.199/32",
+              "20.49.214.228/32",
+              "20.58.23.145/32",
+              "51.149.249.0/27",
+              "51.149.249.32/27",
+              "51.149.250.0/23",
+              "128.77.75.64/26",
+              "194.33.192.0/24",
+              "194.33.196.0/24",
+              "194.33.200.0/21",
+              "194.33.216.0/23",
+              "194.33.218.0/24",
+              "194.33.248.0/24",
+              "194.33.249.0/24",
+              "195.59.75.0/24",
+              #Prod Hubs
+              "20.50.108.242/32",
+              "20.50.109.148/32",
+              #NonProd Hubs
+              "20.49.168.141/32",
+              "20.49.168.17/32",
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
     name          = "ejudiciary-home"
     custom_domain = "home.ejudiciary.net"
     dns_zone_name = "ejudiciary.net"

--- a/environments/stg/stg.tfvars
+++ b/environments/stg/stg.tfvars
@@ -802,6 +802,55 @@ frontends = [
     ]
   },
   {
+    product        = "juror-er-portal"
+    name           = "juror-er-portal"
+    custom_domain  = "juror-er.staging.apps.hmcts.net"
+    dns_zone_name  = "apps.hmcts.net"
+    backend_domain = ["firewall-prod-int-palo-sdsstg.uksouth.cloudapp.azure.com"]
+    cache_enabled  = "false"
+    mode           = "Prevention"
+    custom_rules = [
+      {
+        name     = "IPMatchWhitelist"
+        priority = 1
+        type     = "MatchRule"
+        action   = "Block"
+        match_conditions = [
+          {
+            match_variable     = "RemoteAddr"
+            operator           = "IPMatch"
+            negation_condition = true
+            match_values = [
+              "20.26.11.71/32",
+              "20.26.11.108/32",
+              "20.49.214.199/32",
+              "20.49.214.228/32",
+              "20.58.23.145/32",
+              "51.149.249.0/27",
+              "51.149.249.32/27",
+              "51.149.250.0/23",
+              "128.77.75.64/26",
+              "194.33.192.0/24",
+              "194.33.196.0/24",
+              "194.33.200.0/21",
+              "194.33.216.0/23",
+              "194.33.218.0/24",
+              "194.33.248.0/24",
+              "194.33.249.0/24",
+              "195.59.75.0/24",
+              #Prod Hubs
+              "20.50.108.242/32",
+              "20.50.109.148/32",
+              #NonProd Hubs
+              "20.49.168.141/32",
+              "20.49.168.17/32",
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
     name           = "opal-frontend"
     custom_domain  = "opal-frontend.staging.platform.hmcts.net"
     dns_zone_name  = "staging.platform.hmcts.net"

--- a/environments/test/test.tfvars
+++ b/environments/test/test.tfvars
@@ -535,6 +535,55 @@ frontends = [
     ]
   },
   {
+    product        = "juror-er-portal"
+    name           = "juror-er-portal"
+    custom_domain  = "juror-er.staging.apps.hmcts.net"
+    dns_zone_name  = "apps.hmcts.net"
+    backend_domain = ["firewall-prod-int-palo-sdsstg.uksouth.cloudapp.azure.com"]
+    cache_enabled  = "false"
+    mode           = "Prevention"
+    custom_rules = [
+      {
+        name     = "IPMatchWhitelist"
+        priority = 1
+        type     = "MatchRule"
+        action   = "Block"
+        match_conditions = [
+          {
+            match_variable     = "RemoteAddr"
+            operator           = "IPMatch"
+            negation_condition = true
+            match_values = [
+              "20.26.11.71/32",
+              "20.26.11.108/32",
+              "20.49.214.199/32",
+              "20.49.214.228/32",
+              "20.58.23.145/32",
+              "51.149.249.0/27",
+              "51.149.249.32/27",
+              "51.149.250.0/23",
+              "128.77.75.64/26",
+              "194.33.192.0/24",
+              "194.33.196.0/24",
+              "194.33.200.0/21",
+              "194.33.216.0/23",
+              "194.33.218.0/24",
+              "194.33.248.0/24",
+              "194.33.249.0/24",
+              "195.59.75.0/24",
+              #Prod Hubs
+              "20.50.108.242/32",
+              "20.50.109.148/32",
+              #NonProd Hubs
+              "20.49.168.141/32",
+              "20.49.168.17/32",
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
     name           = "opal-frontend"
     custom_domain  = "opal-frontend.test.platform.hmcts.net"
     dns_zone_name  = "test.platform.hmcts.net"


### PR DESCRIPTION
### Jira link

See [JS-673](https://tools.hmcts.net/jira/browse/JS-673)

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## Link to Terraform Plan ##

https://tfplan-viewer.hmcts.net/sds-azure-platform/1028



## 🤖AEP PR SUMMARY🤖



- **environments/demo/demo.tfvars** 🚧
  - Added new frontend configuration for \"juror-er-portal\" with:
    - Custom domain `juror-er.demo.apps.hmcts.net`
    - Backend domain pointing to a firewall
    - Cache disabled and mode set to \"Prevention\"
    - Custom IP whitelist block rule with a specific set of IP ranges

- **environments/ithc/ithc.tfvars** 🚧
  - Introduced similar \"juror-er-portal\" frontend settings as in demo, including IP whitelist rule and firewall backend domain for ithc environment

- **environments/prod/prod.tfvars** 🚧
  - Added \"juror-er-portal\" frontend with:
    - Production domain `juror-er.prod.apps.hmcts.net`
    - Corresponding backend firewall domain
    - Disabled cache, mode \"Prevention\"
    - Custom IP whitelist blocking rule

- **environments/stg/stg.tfvars** 🚧
  - Deployment of the \"juror-er-portal\" frontend for staging environment:
    - Domain `juror-er.staging.apps.hmcts.net`
    - Firewall backend domain
    - Cache off, mode \"Prevention\"
    - IP whitelist block custom rule identical to other environments

- **environments/test/test.tfvars** 🚧
  - Added \"juror-er-portal\" frontend matching staging settings:
    - Domain uses `juror-er.staging.apps.hmcts.net`
    - Backend firewall domain for staging
    - Cache disabled, mode \"Prevention\"
    - Included the same IP whitelist blocking rule

Summary: This PR introduces consistent configurations for a new frontend service \"juror-er-portal\" across all environments (demo, ithc, prod, stg, test) with IP whitelisting rules, cache disabled, and mode set to Prevention. 🛡️
