### PR TITLE
juror: fix typo

### DIFF
--- a/environments/test/test.tfvars
+++ b/environments/test/test.tfvars
@@ -537,7 +537,7 @@ frontends = [
   {
     product        = "juror-er-portal"
     name           = "juror-er-portal"
-    custom_domain  = "juror-er.staging.apps.hmcts.net"
+    custom_domain  = "juror-er.test.apps.hmcts.net"
     dns_zone_name  = "apps.hmcts.net"
     backend_domain = ["firewall-prod-int-palo-sdsstg.uksouth.cloudapp.azure.com"]
     cache_enabled  = "false"


### PR DESCRIPTION
### Jira link

See [JS-673](https://tools.hmcts.net/jira/browse/JS-673)

### Change description

Updated test to correct my typo


## Link to Terraform Plan ##

https://tfplan-viewer.hmcts.net/sds-azure-platform/1029

## 🤖AEP PR SUMMARY🤖



### environments/test/test.tfvars
- 🛠️ Updated the `custom_domain` for the `juror-er-portal` frontend from `\"juror-er.staging.apps.hmcts.net\"` to `\"juror-er.test.apps.hmcts.net\"` to reflect the test environment domain change.