### PR TITLE
PUB-3098 Add global exclusion for request cookie for CaTH on all environments

### DIFF
--- a/environments/demo/demo.tfvars
+++ b/environments/demo/demo.tfvars
@@ -128,6 +128,11 @@ frontends = [
       {
         match_variable = "RequestCookieNames"
         operator       = "Equals"
+        selector       = "listTypeSensitivityCookie"
+      },
+      {
+        match_variable = "RequestCookieNames"
+        operator       = "Equals"
         selector       = "session"
       },
       {

--- a/environments/ithc/ithc.tfvars
+++ b/environments/ithc/ithc.tfvars
@@ -87,6 +87,11 @@ frontends = [
       {
         match_variable = "RequestCookieNames"
         operator       = "Equals"
+        selector       = "listTypeSensitivityCookie"
+      },
+      {
+        match_variable = "RequestCookieNames"
+        operator       = "Equals"
         selector       = "session"
       },
       {

--- a/environments/prod/prod.tfvars
+++ b/environments/prod/prod.tfvars
@@ -308,6 +308,11 @@ frontends = [
       {
         match_variable = "RequestCookieNames"
         operator       = "Equals"
+        selector       = "listTypeSensitivityCookie"
+      },
+      {
+        match_variable = "RequestCookieNames"
+        operator       = "Equals"
         selector       = "session"
       },
       {

--- a/environments/stg/stg.tfvars
+++ b/environments/stg/stg.tfvars
@@ -113,6 +113,11 @@ frontends = [
       {
         match_variable = "RequestCookieNames"
         operator       = "Equals"
+        selector       = "listTypeSensitivityCookie"
+      },
+      {
+        match_variable = "RequestCookieNames"
+        operator       = "Equals"
         selector       = "session"
       },
       {


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/PUB-3098

### Change description

Add global exclusion for request cookie for CaTH on all environments

### Testing done

Manually added the new request cookie to the global WAF exclusion list on the test env. Genuine requests no longer getting blocked.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## Link to Terraform Plan ##

https://tfplan-viewer.hmcts.net/sds-azure-platform/1035

## 🤖AEP PR SUMMARY🤖



- environments/demo/demo.tfvars 🎯  
  Added a new frontend match rule for `RequestCookieNames` with the selector `listTypeSensitivityCookie`.

- environments/ithc/ithc.tfvars 🎯  
  Added a similar frontend match rule for `RequestCookieNames` targeting `listTypeSensitivityCookie`.

- environments/prod/prod.tfvars 🎯  
  Introduced the `listTypeSensitivityCookie` match rule for `RequestCookieNames` within frontends.

- environments/stg/stg.tfvars 🎯  
  Included a new frontend match condition for `RequestCookieNames` with the selector `listTypeSensitivityCookie`.

*Summary:* All environment `.tfvars` files were updated to add a new frontend match entry for the cookie name `listTypeSensitivityCookie`.