### PR TITLE
PUB-3098 Add global exclusion for request cookie for CaTH on test environment

### DIFF
--- a/environments/test/test.tfvars
+++ b/environments/test/test.tfvars
@@ -127,6 +127,11 @@ frontends = [
           {
             match_variable = "RequestCookieNames"
             operator       = "Equals"
+            selector       = "listTypeSensitivityCookie"
+          },
+          {
+            match_variable = "RequestCookieNames"
+            operator       = "Equals"
             selector       = "session"
           },
           {


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/PUB-3098

### Change description

Add global exclusion for request cookie for CaTH on test environment

### Testing done

Manually added the new request cookie to the global WAF exclusion list on the test env. Genuine requests no longer getting blocked.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## Link to Terraform Plan ##

https://tfplan-viewer.hmcts.net/sds-azure-platform/1036

## 🤖AEP PR SUMMARY🤖



### Changes Summary

- **environments/test/test.tfvars** 🚀
  - Added a new frontend matching rule to inspect the \"RequestCookieNames\" for a cookie named \"listTypeSensitivityCookie\".