### PR TITLE
Fix PROD Build

### DIFF
--- a/environments/prod/prod.tfvars
+++ b/environments/prod/prod.tfvars
@@ -417,7 +417,7 @@ frontends = [
 
     custom_rules = [
       {
-        name     = "RateLimit_General_Pages"
+        name     = "RateLimitGeneralPages"
         priority = 20
         type     = "RateLimitRule"
 
@@ -446,7 +446,7 @@ frontends = [
         ]
       },
       {
-        name     = "RateLimit_All_Other_Pages"
+        name     = "RateLimitAllOtherPages"
         priority = 30
         type     = "RateLimitRule"
 


### PR DESCRIPTION
Build failed because "Rule name must start with a letter and contain only numbers and letters"

## Link to Terraform Plan ##

https://tfplan-viewer.hmcts.net/sds-azure-platform/1093

## 🤖AEP PR SUMMARY🤖



- **environments/prod/prod.tfvars** ✏️
  - Renamed custom rate limit rule names for consistency and style:
    - `\"RateLimit_General_Pages\"` changed to `\"RateLimitGeneralPages\"`
    - `\"RateLimit_All_Other_Pages\"` changed to `\"RateLimitAllOtherPages\"`