### PR TITLE
Update stg.tfvars

### DIFF
--- a/environments/stg/stg.tfvars
+++ b/environments/stg/stg.tfvars
@@ -1074,21 +1074,6 @@ frontends = [
     ]
   },
   {
-    name           = "opal-rm-frontend"
-    custom_domain  = "opal-rm-frontend.staging.apps.hmcts.net"
-    dns_zone_name  = "staging.apps.hmcts.net"
-    backend_domain = ["firewall-prod-int-palo-sdsstg.uksouth.cloudapp.azure.com"]
-    cache_enabled  = "false"
-    disabled_rules = {
-      SQLI = [
-        "942440",
-        "942430",
-        "942450"
-      ],
-    }
-    global_exclusions = []
-  },
-  {
     name           = "hmcts-courtfines-staging"
     custom_domain  = "courtfines-app.staging.platform.hmcts.net"
     dns_zone_name  = "staging.platform.hmcts.net"


### PR DESCRIPTION
We need to remove the opal config as it's moving from platform.hmcts.net to apps.hmcts.net, but it's causing issues within Frontdoor.
This is a change to remove the final domain that's blocking staging.

## Link to Terraform Plan ##

https://tfplan-viewer.hmcts.net/sds-azure-platform/1097