### PR TITLE
Add Cookie Policy to CaTH Global Exclusions

### DIFF
--- a/environments/stg/stg.tfvars
+++ b/environments/stg/stg.tfvars
@@ -388,6 +388,11 @@ frontends = [
         selector       = "court-and-tribunal-hearings-cookie-preferences"
       },
       {
+        match_variable = "RequestCookieNames"
+        operator       = "Equals"
+        selector       = "cookie_policy"
+      },
+      {
         match_variable = "QueryStringArgNames"
         operator       = "Equals"
         selector       = "iss"


### PR DESCRIPTION
https://github.com/hmcts/cath-service/issues/565

### Change description

Adding cookie policy to cath-web global exclusions


## Link to Terraform Plan ##

https://tfplan-viewer.hmcts.net/sds-azure-platform/1099

## 🤖AEP PR SUMMARY🤖

Request to AEP failed to process